### PR TITLE
[CM-735] Mark isBoldTextEnabled public

### DIFF
--- a/Sources/YMatterType/Typography/FontRepresentable.swift
+++ b/Sources/YMatterType/Typography/FontRepresentable.swift
@@ -141,10 +141,14 @@ extension FontRepresentable {
             return .black
         }
     }
-}
 
-internal extension FontRepresentable {
-    func isBoldTextEnabled(compatibleWith traitCollection: UITraitCollection?) -> Bool {
+    /// Determines whether the accessibility Bold Text feature is enabled within the given trait collection.
+    /// - Parameter traitCollection: the trait collection to evaluate (or nil to use system settings)
+    /// - Returns: `true` if the accessibility Bold Text feature is enabled.
+    ///
+    /// If `traitCollection` is not `nil`, it checks for `legibilityWeight == .bold`.
+    /// If `traitCollection` is `nil`, then it examines the system wide `UIAccessibility` setting of the same name.
+    public func isBoldTextEnabled(compatibleWith traitCollection: UITraitCollection?) -> Bool {
         guard let traitCollection = traitCollection else {
             return UIAccessibility.isBoldTextEnabled
         }

--- a/Tests/YMatterTypeTests/Typography/FontRepresentableTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontRepresentableTests.swift
@@ -66,6 +66,28 @@ final class FontRepresentableTests: XCTestCase {
         XCTAssertEqual(font.pointSize, systemFont.pointSize)
         XCTAssertEqual(font.lineHeight, systemFont.lineHeight)
     }
+
+    func testIsBoldTextEnabled() {
+        let (sut, _, _) = makeSUT()
+
+        // given a traitCollection with legibilityWeight == .bold, it should return `true`
+        XCTAssertTrue(sut.isBoldTextEnabled(compatibleWith: UITraitCollection(legibilityWeight: .bold)))
+        XCTAssertTrue(sut.isBoldTextEnabled(compatibleWith: UITraitCollection(traitsFrom: [
+            UITraitCollection(preferredContentSizeCategory: .extraLarge),
+            UITraitCollection(legibilityWeight: .bold)
+        ])))
+
+        // given a traitCollection with legibilityWeight != .bold, it should return `false`
+        XCTAssertFalse(sut.isBoldTextEnabled(compatibleWith: UITraitCollection(legibilityWeight: .regular)))
+        XCTAssertFalse(sut.isBoldTextEnabled(compatibleWith: UITraitCollection(legibilityWeight: .unspecified)))
+
+        // given a traitCollection without legibilityWeight trait, it should return `false`
+        XCTAssertFalse(sut.isBoldTextEnabled(compatibleWith: UITraitCollection()))
+        XCTAssertFalse(sut.isBoldTextEnabled(compatibleWith: UITraitCollection(preferredContentSizeCategory: .small)))
+
+        // given traitCollection is nil, it should return the system setting
+        XCTAssertEqual(sut.isBoldTextEnabled(compatibleWith: nil), UIAccessibility.isBoldTextEnabled)
+    }
 }
 
 // We use large tuples in makeSUT()


### PR DESCRIPTION
## Introduction ##

In working on my design systems tutorial I realized I needed access to an internal function.

## Purpose ##

Mark the function in question as public.
Ticket: [CM-735](https://ymedialabs.atlassian.net/browse/CM-735)

## Scope ##

* mark one internal func in FontRepresentable as public
* add documentation comments
* add a comprehensive unit test

## 📈 Coverage ##

##### Code: 100% #####

<img width="694" alt="image" src="https://user-images.githubusercontent.com/1037520/174500716-c1c4a085-1510-455f-b24d-2ace9855fa1f.png">

##### Documentation: 100% #####

<img width="305" alt="image" src="https://user-images.githubusercontent.com/1037520/174500749-21b3332e-ad38-44b3-a536-79653b5361ae.png">
