### PR TITLE
[CM-741] Swift Package Index integration

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets: [YMatterType]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ An opinionated take on Design System Typography for iOS.
 
 This framework uses Figma's concept of Typography to create text-based UI elements (labels, buttons, text fields, and text views) that render themselves as described in Figma design files (especially sizing themselves according to line height) while also supporting Dynamic Type scaling and the Bold Text accessibility setting.
 
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyml-org%2FYMatterType%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/yml-org/YMatterType)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyml-org%2FYMatterType%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/yml-org/YMatterType)
+
 Documentation
 ----------
 


### PR DESCRIPTION
## Introduction ##

Swift Package Index offers some features that may be helpful to our open source repo.

## Purpose ##

Add badges to README showing supported Swift tools versions and supported platforms and enable Swift Package Index to build and host DocC documentation for us.

## Scope ##

* Add badge to README
* Add config file to enable DocC generation

## Discussion ##

We already build our own documentation from source code comments using Jazzy and GitHub Pages, but free hosting of DocC on the SPI website is a nice freebie (and I'm curious to see how it looks). We can always turn it back off if we feel it's a hindrance. It could potentially be a future alternative to Jazzy.

## 📱 Screenshots ##

What the README badges look like:

<img width="458" alt="image" src="https://user-images.githubusercontent.com/1037520/178275946-8782f4a4-7d1b-4018-b8a8-9cf374499ee2.png">

## 📈 Coverage ##

##### Code #####

Unchanged

##### Documentation #####

Unchanged