### PR TITLE
Fix iOS 16 UITextView intrinsicContentSize bug

### DIFF
--- a/Sources/YMatterType/Elements/TypographyTextView.swift
+++ b/Sources/YMatterType/Elements/TypographyTextView.swift
@@ -162,6 +162,16 @@ private extension TypographyTextView {
     }
 
     func configure() {
+        if #available(iOS 16.0, *) {
+            // Starting with iOS 16, UITextView uses TextKit 2 for layout,
+            // which does not behave properly with our attributed text
+            // setting line height. Accessing `layoutManager` forces the text view
+            // to render using the TextKit 1 layout manager.
+            // It would be more efficient to initialize via `UITextView.init(usingTextLayoutManager: false)`,
+            // but that is impossible because it is not a designated initializer.
+            // So for now we have the following solution.
+            _ = layoutManager
+        }
         adjustsFontForContentSizeCategory = true
         textContainerInset = .zero // Typography should provide sufficient insets
     }

--- a/Tests/YMatterTypeTests/Elements/TypographyTextViewTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyTextViewTests.swift
@@ -45,9 +45,9 @@ final class TypographyTextViewTests: TypographyElementTests {
     }
 
     func testMultiLine() {
-        let sut = makeSUT()
-       // Given a text view with text that spans multiple lines
         [2, 3, 5, 8, 13].forEach {
+            // Given a text view with text that spans multiple lines
+            let sut = makeSUT()
             let array: [String] = Array(repeating: "Hello World", count: $0)
             sut.text = array.joined(separator: "\n")
 


### PR DESCRIPTION
## Introduction ##

Using latest Xcode 14 beta, unit tests for `TypographyTextView` would fail when targeting iOS 16.

## Purpose ##

Fix our text view so that it sizes itself properly (as a multiple of line height) under iOS 16

## Scope ##

* iOS 16-only change to `TypographyTextView`
* slight change to a unit test

## Discussion ##

Starting with iOS 16, `UITextView` uses TextKit 2 text layout manager to render text view content. For whatever reason, when rendered in this manner the text view's intrinsic content size does not reflect the number of lines despite our use of attributed text attributes to set line height. However, there is a work around to get the text view to render using the legacy TextKit 1 layout manager. Using the original layout manager the text view's have the expected intrinsic content size.

## 📈 Coverage ##

##### Code #####

99.3% when testing iOS 15, 100% when testing iOS 16
(because there's a line of code that only runs on iOS 16)

<img width="642" alt="image" src="https://user-images.githubusercontent.com/1037520/185407887-405226e4-01e1-4566-8c91-681c0d77ef30.png">

##### Documentation #####

100%

<img width="402" alt="image" src="https://user-images.githubusercontent.com/1037520/185407773-c230ab32-3057-4bfe-b406-a140f1b858b5.png">
