### PR TITLE
Rename `FontRepresentable` to `FontFamily`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,12 @@ extension Typography {
 
 ## Custom Font Families
 
-Y—MatterType does its best to automatically map font family name, font style (regular or italic), and font weight (ultralight to black) into the registered name of the font so that it may be loaded using `UIFont(name:, size:)`. (This registered font name may differ from the name of the font file and from the display name for the font family.) However, some font families may require custom behavior in order to properly load the font (e.g. the semibold font weight might be named "DemiBold" instead of the more common "SemiBold"). To support this you can declare a class or struct that conforms to the `FontRepresentable` protocol and use that to initialize your `Typography` instance. This protocol has four methods, each of which may be optionally overridden to customize how fonts of a given weight are loaded. The framework contains three different implementations of `FontRepresentable` for you to consider (`FontInfo`, `SystemFontInfo`, and `SFProFontFamily`).
+Y—MatterType does its best to automatically map font family name, font style (regular or italic), and font weight (ultralight to black) into the registered name of the font so that it may be loaded using `UIFont(name:, size:)`. (This registered font name may differ from the name of the font file and from the display name for the font family.) However, some font families may require custom behavior in order to properly load the font (e.g. the semibold font weight might be named "DemiBold" instead of the more common "SemiBold"). To support this you can declare a class or struct that conforms to the `FontFamily` protocol and use that to initialize your `Typography` instance. This protocol has four methods, each of which may be optionally overridden to customize how fonts of a given weight are loaded. The framework contains three different implementations of `FontFamily` for you to consider (`FontInfo`, `SystemFontInfo`, and `SFProFontFamily`).
 
 In the event that the requested font cannot be loaded (either the name is incorrect or it was not registered), Y—MatterType will fall back to loading a system font of the specified point size and weight.
 
 ```
-struct AppleSDGothicNeoInfo: FontRepresentable {
+struct AppleSDGothicNeoInfo: FontFamily {
     /// Font family root name
     let familyName: String = "AppleSDGothicNeo"
     

--- a/Sources/YMatterType/Typography/FontFamily.swift
+++ b/Sources/YMatterType/Typography/FontFamily.swift
@@ -1,5 +1,5 @@
 //
-//  FontRepresentable.swift
+//  FontFamily.swift
 //  YMatterType
 //
 //  Created by Mark Pospesel on 8/23/21.
@@ -10,20 +10,20 @@ import UIKit
 import os
 
 /// Information about a font family. When an app specifies a custom font, they will
-/// implement an instance of FontRepresentable to fully describe that font.
-public protocol FontRepresentable {
+/// implement an instance of FontFamily to fully describe that font.
+public protocol FontFamily {
     /// Font family root name, e.g. "AvenirNext"
     var familyName: String { get }
     
     /// Optional suffix to use for the font name.
     ///
-    /// Used by `FontRepresentable.fontName(for:compatibleWith:)`
+    /// Used by `FontFamily.fontName(for:compatibleWith:)`
     /// e.g. "Italic" is a typical suffix for italic fonts.
     /// default = ""
     var fontNameSuffix: String { get }
     
     // The following four methods have default implementations that
-    // can be overridden in custom implementations of FontRepresentable
+    // can be overridden in custom implementations of FontFamily
     
     /// Returns a font for the specified `weight` and `pointSize` that is compatible with the `traitCollection`
     /// - Parameters:
@@ -63,7 +63,7 @@ extension Typography {
 
 // MARK: - Default implementations
 
-extension FontRepresentable {
+extension FontFamily {
     public var fontNameSuffix: String { "" }
 
     public func font(
@@ -156,3 +156,10 @@ extension FontRepresentable {
         return traitCollection.legibilityWeight == .bold
     }
 }
+
+/// Information about a font family. When an app specifies a custom font, they will
+/// implement an instance of FontFamily to fully describe that font.
+///
+/// Renamed to `FontFamily`
+@available(*, deprecated, renamed: "FontFamily")
+public typealias FontRepresentable = FontFamily

--- a/Sources/YMatterType/Typography/FontInfo.swift
+++ b/Sources/YMatterType/Typography/FontInfo.swift
@@ -8,8 +8,8 @@
 
 import UIKit
 
-/// Information about a font family. Default implementation of FontRepresentable.
-public struct FontInfo: FontRepresentable {
+/// Information about a font family. Default implementation of FontFamily.
+public struct FontInfo: FontFamily {
     /// Suffix to use for italic family font names "Italic"
     public static let italicSuffix = "Italic"
     
@@ -30,7 +30,7 @@ public struct FontInfo: FontRepresentable {
     
     /// Optional suffix to use for the font name.
     ///
-    /// Used by `FontRepresentable.fontName(for:compatibleWith:)`
+    /// Used by `FontFamily.fontName(for:compatibleWith:)`
     /// e.g. "Italic" is a typical suffix for italic fonts.
     /// default = ""
     public var fontNameSuffix: String {

--- a/Sources/YMatterType/Typography/SystemFontInfo.swift
+++ b/Sources/YMatterType/Typography/SystemFontInfo.swift
@@ -36,11 +36,11 @@ public extension Typography.FontWeight {
 
 public extension FontInfo {
     /// Information about the system font family
-    static let system: FontRepresentable = SystemFontInfo()
+    static let system: FontFamily = SystemFontInfo()
 }
 
-/// Information about the system font. System font implementation of FontRepresentable.
-public struct SystemFontInfo: FontRepresentable {
+/// Information about the system font. System font implementation of FontFamily.
+public struct SystemFontInfo: FontFamily {
     // The system font has a private font family name (literally ".SFUI"), so
     // just return empty string for familyName. The system font can't be retrieved by name anyway.
     public var familyName: String { "" }

--- a/Sources/YMatterType/Typography/Typography+SFPro.swift
+++ b/Sources/YMatterType/Typography/Typography+SFPro.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Typographical information about Apple's SF family of fonts
-public struct SFProFontFamily: FontRepresentable {
+public struct SFProFontFamily: FontFamily {
     fileprivate enum SFProFamily {
         case display
         case displayItalic
@@ -72,7 +72,7 @@ public struct SFProFontFamily: FontRepresentable {
     
     /// Optional suffix to use for the font name.
     ///
-    /// Used by `FontRepresentable.fontName(for:compatibleWith:)`
+    /// Used by `FontFamily.fontName(for:compatibleWith:)`
     /// e.g. "Italic" is a typical suffix for italic fonts.
     /// default = ""
     public var fontNameSuffix: String {

--- a/Sources/YMatterType/Typography/Typography.swift
+++ b/Sources/YMatterType/Typography/Typography.swift
@@ -11,7 +11,7 @@ import UIKit
 /// Represents a font as it would appear in a design document
 public struct Typography {
     /// Information about the font family
-    public let fontFamily: FontRepresentable
+    public let fontFamily: FontFamily
     /// Font weight
     public let fontWeight: FontWeight
     /// Font size (aka point size)
@@ -48,7 +48,7 @@ public struct Typography {
     ///   - textStyle: text style to use for scaling (defaults to `.body`)
     ///   - isFixed: `true` if this font should never scale, `false` if it should scale (defaults to `.false`)
     public init(
-        fontFamily: FontRepresentable,
+        fontFamily: FontFamily,
         fontWeight: FontWeight,
         fontSize: CGFloat,
         lineHeight: CGFloat,

--- a/Sources/YMatterType/Typography/TypographyLayout.swift
+++ b/Sources/YMatterType/Typography/TypographyLayout.swift
@@ -60,7 +60,11 @@ public struct TypographyLayout {
         self.paragraphSpacing = paragraphSpacing
         self.textCase = textCase
         self.textDecoration = textDecoration
-        self.paragraphStyle = NSParagraphStyle.default.styleWithLineHeight(lineHeight, indent: paragraphIndent, spacing: paragraphSpacing)
+        self.paragraphStyle = NSParagraphStyle.default.styleWithLineHeight(
+            lineHeight,
+            indent: paragraphIndent,
+            spacing: paragraphSpacing
+        )
     }
 }
 

--- a/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
@@ -56,7 +56,10 @@ final class TypographyLabelTests: TypographyElementTests {
             sut.text = array.joined(separator: "\n")
 
             // we expect label height to be a multiple of lineHeight + paragraph spacing
-            XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight * CGFloat($0) + spacing * CGFloat($0 - 1))
+            XCTAssertEqual(
+                sut.intrinsicContentSize.height,
+                sut.typography.lineHeight * CGFloat($0) + spacing * CGFloat($0 - 1)
+            )
             // after calling sizeToFit we expect bounds to equal intrinsicContentSize
             sut.sizeToFit()
             XCTAssertEqual(sut.intrinsicContentSize, sut.bounds.size)

--- a/Tests/YMatterTypeTests/Elements/TypographyTextViewTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyTextViewTests.swift
@@ -53,7 +53,10 @@ final class TypographyTextViewTests: TypographyElementTests {
             sut.text = array.joined(separator: "\n")
 
             // we expect label height to be a multiple of lineHeight + paragraph spacing
-            XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight * CGFloat($0) + spacing * CGFloat($0 - 1))
+            XCTAssertEqual(
+                sut.intrinsicContentSize.height,
+                sut.typography.lineHeight * CGFloat($0) + spacing * CGFloat($0 - 1)
+            )
             // after calling sizeToFit we expect bounds to equal intrinsicContentSize
             sut.sizeToFit()
             XCTAssertEqual(sut.intrinsicContentSize, sut.bounds.size)

--- a/Tests/YMatterTypeTests/Typography/FontFamilyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontFamilyTests.swift
@@ -1,5 +1,5 @@
 //
-//  FontRepresentableTests.swift
+//  FontFamilyTests.swift
 //  YMatterTypeTests
 //
 //  Created by Mark Pospesel on 8/24/21.
@@ -9,7 +9,7 @@
 import XCTest
 @testable import YMatterType
 
-final class FontRepresentableTests: XCTestCase {
+final class FontFamilyTests: XCTestCase {
     func testFontName() {
         let (sut, weightNames, traitCollection) = makeSUT()
         for weight in Typography.FontWeight.allCases {
@@ -93,12 +93,12 @@ final class FontRepresentableTests: XCTestCase {
 // We use large tuples in makeSUT()
 // swiftlint:disable large_tuple
 
-private extension FontRepresentableTests {
+private extension FontFamilyTests {
     func makeSUT(
         file: StaticString = #filePath,
         line: UInt = #line
-    ) -> (FontRepresentable, [Typography.FontWeight: String], UITraitCollection) {
-        let sut = MockFontRepresentable()
+    ) -> (FontFamily, [Typography.FontWeight: String], UITraitCollection) {
+        let sut = MockFontFamily()
         let weightNames: [Typography.FontWeight: String] = [
             .ultralight: "ExtraLight",
             .thin: "Thin",
@@ -117,6 +117,6 @@ private extension FontRepresentableTests {
     }
 }
 
-final class MockFontRepresentable: FontRepresentable {
+final class MockFontFamily: FontFamily {
     let familyName: String = "MockSerifMono"
 }

--- a/Tests/YMatterTypeTests/Typography/SystemFontInfoTests.swift
+++ b/Tests/YMatterTypeTests/Typography/SystemFontInfoTests.swift
@@ -35,7 +35,7 @@ final class SystemFontInfoTests: XCTestCase {
 // swiftlint:disable large_tuple
 
 private extension SystemFontInfoTests {
-    func makeSUT() -> (FontRepresentable, [CGFloat], [UITraitCollection?]) {
+    func makeSUT() -> (FontFamily, [CGFloat], [UITraitCollection?]) {
         super.setUp()
         let sut = FontInfo.system
         let pointSizes: [CGFloat] = [10, 12, 14, 16, 18, 24, 28, 32]

--- a/Tests/YMatterTypeTests/Typography/Typography+FontTests.swift
+++ b/Tests/YMatterTypeTests/Typography/Typography+FontTests.swift
@@ -157,7 +157,7 @@ final class TypographyFontTests: XCTestCase {
     }
 }
 
-struct AppleSDGothicNeoInfo: FontRepresentable {
+struct AppleSDGothicNeoInfo: FontFamily {
     let familyName: String = "AppleSDGothicNeo"
     
     func weightName(for weight: Typography.FontWeight) -> String {

--- a/Tests/YMatterTypeTests/Typography/Typography+SFProTests.swift
+++ b/Tests/YMatterTypeTests/Typography/Typography+SFProTests.swift
@@ -44,7 +44,7 @@ final class TypographySFProTests: XCTestCase {
 }
 
 private extension TypographySFProTests {
-    func _testFontFamily(_ fontFamily: FontRepresentable, style: Typography.FontStyle) {
+    func _testFontFamily(_ fontFamily: FontFamily, style: Typography.FontStyle) {
         Typography.FontWeight.allCases.forEach {
             let typography = Typography(
                 fontFamily: fontFamily,


### PR DESCRIPTION
## Introduction ##

Naming is hard! I think `FontFamily` is a better name than `FontRepresentable` that we originally used. It doesn't represent a font, it represents an entire family of fonts.

## Purpose ##

Rename `FontRepresentable` to `FontFamily`

## Scope ##

* Replace all instances (including in README)
* Add a `typealias` for backwards compatibility, but deprecate it so folks know to rename

## 📈 Coverage ##

Code and documentation coverage were both unchanged. Just renaming.