### PR TITLE
Rename SystemFontInfo to SystemFontFamily

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Just want to use the default system fonts? Y—MatterType has you covered.
 extension Typography {
     /// System font, Semibold 17/22 pts
     static let headline = Typography(
-        fontFamily: FontInfo.system,
+        fontFamily: Typography.systemFamily,
         fontWeight: .semibold,
         fontSize: 17,
         lineHeight: 22,
@@ -168,7 +168,7 @@ extension Typography {
 
 ## Custom Font Families
 
-Y—MatterType does its best to automatically map font family name, font style (regular or italic), and font weight (ultralight to black) into the registered name of the font so that it may be loaded using `UIFont(name:, size:)`. (This registered font name may differ from the name of the font file and from the display name for the font family.) However, some font families may require custom behavior in order to properly load the font (e.g. the semibold font weight might be named "DemiBold" instead of the more common "SemiBold"). To support this you can declare a class or struct that conforms to the `FontFamily` protocol and use that to initialize your `Typography` instance. This protocol has four methods, each of which may be optionally overridden to customize how fonts of a given weight are loaded. The framework contains three different implementations of `FontFamily` for you to consider (`FontInfo`, `SystemFontInfo`, and `SFProFontFamily`).
+Y—MatterType does its best to automatically map font family name, font style (regular or italic), and font weight (ultralight to black) into the registered name of the font so that it may be loaded using `UIFont(name:, size:)`. (This registered font name may differ from the name of the font file and from the display name for the font family.) However, some font families may require custom behavior in order to properly load the font (e.g. the semibold font weight might be named "DemiBold" instead of the more common "SemiBold"). To support this you can declare a class or struct that conforms to the `FontFamily` protocol and use that to initialize your `Typography` instance. This protocol has four methods, each of which may be optionally overridden to customize how fonts of a given weight are loaded. The framework contains three different implementations of `FontFamily` for you to consider (`FontInfo`, `SystemFontFamily`, and `SFProFontFamily`).
 
 In the event that the requested font cannot be loaded (either the name is incorrect or it was not registered), Y—MatterType will fall back to loading a system font of the specified point size and weight.
 

--- a/Sources/YMatterType/Typography/FontFamily.swift
+++ b/Sources/YMatterType/Typography/FontFamily.swift
@@ -75,7 +75,7 @@ extension FontFamily {
         guard let font = UIFont(name: name, size: pointSize) else {
             // Fallback to system font and log a message.
             Typography.logger.warning("Custom font \(name) not properly installed.")
-            return FontInfo.system.font(
+            return Typography.systemFamily.font(
                 for: weight,
                 pointSize: pointSize,
                 compatibleWith: traitCollection

--- a/Sources/YMatterType/Typography/SystemFontFamily.swift
+++ b/Sources/YMatterType/Typography/SystemFontFamily.swift
@@ -1,5 +1,5 @@
 //
-//  SystemFontInfo.swift
+//  SystemFontFamily.swift
 //  YMatterType
 //
 //  Created by Mark Pospesel on 9/28/21.
@@ -34,13 +34,21 @@ public extension Typography.FontWeight {
     }
 }
 
-public extension FontInfo {
+public extension Typography {
     /// Information about the system font family
-    static let system: FontFamily = SystemFontInfo()
+    static let systemFamily: FontFamily = SystemFontFamily()
+}
+
+extension FontInfo {
+    /// Information about the system font family
+    ///
+    /// Renamed to `Typography.systemFamily`
+    @available(*, deprecated, renamed: "Typography.systemFamily")
+    static var system: FontFamily { Typography.systemFamily }
 }
 
 /// Information about the system font. System font implementation of FontFamily.
-public struct SystemFontInfo: FontFamily {
+public struct SystemFontFamily: FontFamily {
     // The system font has a private font family name (literally ".SFUI"), so
     // just return empty string for familyName. The system font can't be retrieved by name anyway.
     public var familyName: String { "" }

--- a/Sources/YMatterType/Typography/Typography+System.swift
+++ b/Sources/YMatterType/Typography/Typography+System.swift
@@ -39,7 +39,7 @@ extension Typography {
     ) -> Typography {
         let lineHeight = ceil(fontSize * systemLineHeightMultiple)
         return Typography(
-            fontFamily: FontInfo.system,
+            fontFamily: Typography.systemFamily,
             fontWeight: weight,
             fontSize: fontSize,
             lineHeight: lineHeight,

--- a/Tests/YMatterTypeTests/Typography/FontFamilyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontFamilyTests.swift
@@ -60,7 +60,7 @@ final class FontFamilyTests: XCTestCase {
         // This isn't a real font, so we expect it to fallback to the system font
         let (sut, _, _) = makeSUT()
         let font = sut.font(for: .regular, pointSize: 16, compatibleWith: .default)
-        let systemFont = FontInfo.system.font(for: .regular, pointSize: 16, compatibleWith: .default)
+        let systemFont = Typography.systemFamily.font(for: .regular, pointSize: 16, compatibleWith: .default)
         XCTAssertEqual(font.familyName, systemFont.familyName)
         XCTAssertEqual(font.fontName, systemFont.fontName)
         XCTAssertEqual(font.pointSize, systemFont.pointSize)

--- a/Tests/YMatterTypeTests/Typography/SystemFontFamilyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/SystemFontFamilyTests.swift
@@ -1,5 +1,5 @@
 //
-//  SystemFontInfoTests.swift
+//  SystemFontFamilyTests.swift
 //  YMatterTypeTests
 //
 //  Created by Mark Pospesel on 9/28/21.
@@ -9,7 +9,7 @@
 import XCTest
 @testable import YMatterType
 
-final class SystemFontInfoTests: XCTestCase {
+final class SystemFontFamilyTests: XCTestCase {
     func testFont() throws {
         let (sut, pointSizes, traitCollections) = makeSUT()
         let systemFont = UIFont.systemFont(ofSize: 12)
@@ -34,10 +34,10 @@ final class SystemFontInfoTests: XCTestCase {
 // We use large tuples in makeSUT()
 // swiftlint:disable large_tuple
 
-private extension SystemFontInfoTests {
+private extension SystemFontFamilyTests {
     func makeSUT() -> (FontFamily, [CGFloat], [UITraitCollection?]) {
         super.setUp()
-        let sut = FontInfo.system
+        let sut = Typography.systemFamily
         let pointSizes: [CGFloat] = [10, 12, 14, 16, 18, 24, 28, 32]
         let traitCollections: [UITraitCollection?] = [
             nil,


### PR DESCRIPTION
## Introduction ##

Naming is hard! This PR is part of a series of renaming PR's.

## Purpose ##

Rename `SystemFontInfo` to `SystemFontFamily` because it conforms to the `FontFamily` protocol (also it's not info about any single font but about a family of fonts)

## Scope ##

* Replace all instances of `SystemFontInfo` with the new name
* For backwards compatibility creates a `typealias` from the original name (but mark it as deprecated)
* Rename `FontInfo.system` to `Typography.systemFamily` which is more in line with how other concrete implementations of `FontFamily` have been organized.

## 📈 Coverage ##

Coverage was not materially changed by this renaming operation.