### PR TITLE
Allow user to change Typography’s default font factory

### DIFF
--- a/Sources/YMatterType/Typography/Typography.swift
+++ b/Sources/YMatterType/Typography/Typography.swift
@@ -33,7 +33,15 @@ public struct Typography {
     public let textStyle: UIFont.TextStyle
     /// Whether this font is fixed in size or should be scaled through Dynamic Type
     public let isFixed: Bool
-    
+
+    /// The factory to use to convert from family name + font style into a `FontFamily`.
+    /// The default is to use `DefaultFontFamilyFactory`.
+    ///
+    /// If you use a custom font family (or families) in your project, create your own factory to
+    /// return the correct font family and then set it here, preferably as early as possible in the
+    /// app launch lifecycle.
+    public static var factory: FontFamilyFactory = DefaultFontFamilyFactory()
+
     /// Initializes a typography instance with the specified parameters
     /// - Parameters:
     ///   - fontFamily: font family to use
@@ -102,7 +110,7 @@ public struct Typography {
         isFixed: Bool = false
     ) {
         self.init(
-            fontFamily: DefaultFontFamily(familyName: familyName, style: fontStyle),
+            fontFamily: Self.factory.getFontFamily(familyName: familyName, style: fontStyle),
             fontWeight: fontWeight,
             fontSize: fontSize,
             lineHeight: lineHeight,

--- a/Tests/YMatterTypeTests/Typography/TypogaphyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/TypogaphyTests.swift
@@ -13,18 +13,37 @@ final class TypogaphyTests: XCTestCase {
     func testInit() {
         // test the default initializer
         let avenir = DefaultFontFamily(familyName: "AvenirNext")
-        let typeInfo = Typography(fontFamily: avenir, fontWeight: .bold, fontSize: 16, lineHeight: 24)
-        
-        XCTAssertNotNil(typeInfo.generateLayout(compatibleWith: .default))
+        let typeInfo = Typography(fontFamily: avenir, fontWeight: .regular, fontSize: 16, lineHeight: 24)
+        let layout = typeInfo.generateLayout(compatibleWith: .default)
+
+        XCTAssertEqual(layout.font.familyName, "Avenir Next")
         _testDefaults(typeInfo)
     }
 
     func testInit2() {
         // test the convenience initializer
-        let typeInfo = Typography(familyName: "AvenirNext", fontWeight: .bold, fontSize: 16, lineHeight: 24)
-        
-        XCTAssertNotNil(typeInfo.generateLayout(compatibleWith: .default))
+        let typeInfo = Typography(familyName: "AvenirNext", fontWeight: .regular, fontSize: 16, lineHeight: 24)
+        let layout = typeInfo.generateLayout(compatibleWith: .default)
+
+        XCTAssertEqual(layout.font.familyName, "Avenir Next")
         _testDefaults(typeInfo)
+    }
+
+    func testFactory() throws {
+        // Given
+        Typography.factory = NotoSansFactory()
+        try UIFont.register(name: "NotoSans-Regular")
+        addTeardownBlock {
+            Typography.factory = DefaultFontFamilyFactory()
+            try UIFont.unregister(name: "NotoSans-Regular")
+        }
+
+        // When
+        let typeInfo = Typography(familyName: "AvenirNext", fontWeight: .regular, fontSize: 16, lineHeight: 24)
+        let layout = typeInfo.generateLayout(compatibleWith: .default)
+
+        // Then
+        XCTAssertEqual(layout.font.familyName, "Noto Sans")
     }
 
     private func _testDefaults(_ typography: Typography) {
@@ -32,5 +51,20 @@ final class TypogaphyTests: XCTestCase {
         XCTAssertEqual(typography.letterSpacing, 0)
         XCTAssertEqual(typography.textStyle, UIFont.TextStyle.body)
         XCTAssertFalse(typography.isFixed)
+    }
+}
+
+struct NotoSansFontFamily: FontFamily {
+    let familyName = "NotoSans"
+}
+
+extension Typography {
+    static let notoSans = NotoSansFontFamily()
+}
+
+struct NotoSansFactory: FontFamilyFactory {
+    // Always returns Noto Sans font family
+    func getFontFamily(familyName: String, style: YMatterType.Typography.FontStyle) -> YMatterType.FontFamily {
+        Typography.notoSans
     }
 }


### PR DESCRIPTION
## Introduction ##

To better support machine-generated instantiation of Typography objects (i.e. export from Figma tokens via a plugin) we need a way to map from the family name strings exported as tokens to a potentially custom `FontFamily` that would be project specific.

## Purpose ##

Add the ability to alter the factory that Typography uses by default to map from a font family name (String) to a `FontFamily` object.

## Scope ##

* add static `factory` variable to Typography
* modify the convenience initializer to use the factory to map family name + font style to a `FontFamily`

## 📈 Coverage ##

##### Code: 99.9% #####

<img width="657" alt="image" src="https://user-images.githubusercontent.com/1037520/191875896-6d46cbb0-fce8-4b41-a231-b0dc9253cd75.png">

##### Documentation: 100% #####

<img width="538" alt="image" src="https://user-images.githubusercontent.com/1037520/191875927-2f35fe5e-e71b-4fb6-9e05-0108305673e5.png">

