### PR TITLE
Add supportedWeights property

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,13 @@ try UIFont.register(
 Because `Bundle.module` is only available from within your Swift package, we recommend that you expose a helper method from within your Swift package to register the fonts and that internally references `Bundle.module`.
 
 ```
-public struct NotoSansFontFamily {
+public struct NotoSansFontFamily: FontFamily {
+    /// Font family root name
+    let familyName: String = "NotoSans"
+    
+    // We've only bundled 3 weights for this font
+    var supportedWeights: [Typography.FontWeight] = [.regular, .medium, .semibold]
+
     /// Register all 3 NotoSans fonts
     public static func registerFonts() throws {
         let names = makeFontNames()
@@ -138,7 +144,9 @@ public struct NotoSansFontFamily {
 ```
 ## Which font weights to include
 
-Fonts can come in up to 9 different weights, ranging from ultralight (100) to black (900), but not all font families will support every weight. Also you might not wish to include fonts for weights which your design system does not use in order to keep your bundle size as small as possible. However, in order to support the Accessibility Bold Text feature (which allows users to request a heavier weight font), for each font weight in your design system, you need to include the next heavier font weight as well. For example, if your design system only uses regular (400) and bold (700) weight fonts, you would need to include (and register) font files for regular (400), medium (500), bold (700), and heavy (800) weight fonts.
+Fonts can come in up to 9 different weights, ranging from ultralight (100) to black (900), but not all font families will support every weight. Also you might not wish to include fonts for weights which your design system does not use in order to keep your bundle size as small as possible. However, in order to support the Accessibility Bold Text feature (which allows users to request a heavier weight font), for each font weight in your design system, you should include the next heavier font weight as well. For example, if your design system only uses regular (400) and bold (700) weight fonts, if possible you should include (and register) font files for regular (400), medium (500), bold (700), and heavy (800) weight fonts. 
+
+When Accessibility Bold Text is enabled, `FontFamily` will use the next heavier font weight listed in `supportedWeights` (if any), and otherwise use the heaviest supported font weight.
 
 ## Using System Fonts
 
@@ -159,7 +167,9 @@ extension Typography {
 
 ## Custom Font Families
 
-Y—MatterType does its best to automatically map font family name, font style (regular or italic), and font weight (ultralight to black) into the registered name of the font so that it may be loaded using `UIFont(name:, size:)`. (This registered font name may differ from the name of the font file and from the display name for the font family.) However, some font families may require custom behavior in order to properly load the font (e.g. the semibold font weight might be named "DemiBold" instead of the more common "SemiBold"). To support this you can declare a class or struct that conforms to the `FontFamily` protocol and use that to initialize your `Typography` instance. This protocol has four methods, each of which may be optionally overridden to customize how fonts of a given weight are loaded. The framework contains two different implementations of `FontFamily` for you to consider (`DefaultFontFamily` and `SystemFontFamily`).
+Y—MatterType does its best to automatically map font family name, font style (regular or italic), and font weight (ultralight to black) into the registered name of the font so that it may be loaded using `UIFont(name:, size:)`. (This registered font name may differ from the name of the font file and from the display name for the font family.) However, some font families may require custom behavior in order to properly load the font (e.g. the semibold font weight might be named "DemiBold" instead of the more common "SemiBold"). Or your font family might not include all 9 possible font weights. To support this you can declare a class or struct that conforms to the `FontFamily` protocol and use that to initialize your `Typography` instance. This protocol has four methods, each of which may be optionally overridden to customize how fonts of a given weight are loaded. The `supportedWeights` property that can be overridden. If your font family does not have access to all 9 font weights, then you should override `supportedWeights` and return the weights of all fonts bundled in your project.
+
+The framework contains two different implementations of `FontFamily` for you to consider (`DefaultFontFamily` and `SystemFontFamily`).
 
 In the event that the requested font cannot be loaded (either the name is incorrect or it was not registered), Y—MatterType will fall back to loading a system font of the specified point size and weight.
 
@@ -168,6 +178,10 @@ struct AppleSDGothicNeoInfo: FontFamily {
     /// Font family root name
     let familyName: String = "AppleSDGothicNeo"
     
+    // This font family doesn't support weights higher than Bold
+    var supportedWeights: [Typography.FontWeight] = 
+        [.ultralight, .thin, .light, .regular, .medium, .semibold, .bold]
+
     /// Generates a weight name suffix as part of a full font name. Not all fonts support all 9 weights.
     /// - Parameter weight: desired font weight
     /// - Returns: The weight name to use

--- a/Tests/YMatterTypeTests/Typography/FontFamily/FontFamilyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontFamily/FontFamilyTests.swift
@@ -38,6 +38,30 @@ final class FontFamilyTests: XCTestCase {
             XCTAssertEqual(sut.accessibilityBoldWeight(for: $0).rawValue, expectedWeight)
         }
     }
+
+    func testSupportedWeights() {
+        let sut = MockFontFamily()
+        sut.supportedWeights = [.light, .semibold, .heavy]
+
+        // Given any weight, we expect it to return the next heavier supported weight
+        XCTAssertEqual(sut.accessibilityBoldWeight(for: .ultralight), .light)
+        XCTAssertEqual(sut.accessibilityBoldWeight(for: .thin), .light)
+        XCTAssertEqual(sut.accessibilityBoldWeight(for: .light), .semibold)
+        XCTAssertEqual(sut.accessibilityBoldWeight(for: .regular), .semibold)
+        XCTAssertEqual(sut.accessibilityBoldWeight(for: .medium), .semibold)
+        XCTAssertEqual(sut.accessibilityBoldWeight(for: .semibold), .heavy)
+        XCTAssertEqual(sut.accessibilityBoldWeight(for: .bold), .heavy)
+
+        // If there is no heavier weight, then we expect it to return the heaviest weight
+        XCTAssertEqual(sut.accessibilityBoldWeight(for: .heavy), .heavy)
+        XCTAssertEqual(sut.accessibilityBoldWeight(for: .black), .heavy)
+
+        // Given no supported weights we expect it to return the weight passed in
+        sut.supportedWeights = []
+        Typography.FontWeight.allCases.forEach {
+            XCTAssertEqual(sut.accessibilityBoldWeight(for: $0), $0)
+        }
+    }
     
     func testCompatibleTraitCollection() {
         let (sut, _, _) = makeSUT()
@@ -119,4 +143,6 @@ private extension FontFamilyTests {
 
 final class MockFontFamily: FontFamily {
     let familyName: String = "MockSerifMono"
+
+    var supportedWeights: [Typography.FontWeight] = Typography.FontWeight.allCases
 }

--- a/Tests/YMatterTypeTests/Typography/TypogaphyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/TypogaphyTests.swift
@@ -56,6 +56,8 @@ final class TypogaphyTests: XCTestCase {
 
 struct NotoSansFontFamily: FontFamily {
     let familyName = "NotoSans"
+
+    var supportedWeights: [Typography.FontWeight] { [.regular] }
 }
 
 extension Typography {

--- a/Tests/YMatterTypeTests/Typography/Typography+FontTests.swift
+++ b/Tests/YMatterTypeTests/Typography/Typography+FontTests.swift
@@ -159,7 +159,10 @@ final class TypographyFontTests: XCTestCase {
 
 struct AppleSDGothicNeoInfo: FontFamily {
     let familyName: String = "AppleSDGothicNeo"
-    
+
+    // This font family doesn't support weights higher than Bold
+    var supportedWeights: [Typography.FontWeight] = [.ultralight, .thin, .light, .regular, .medium, .semibold, .bold]
+
     func weightName(for weight: Typography.FontWeight) -> String {
         switch weight {
         case .ultralight:


### PR DESCRIPTION
## Introduction ##

We don't always have all 9 supported font weights for a given font family (some times they don't even exist, other times we don't want to bundle font weights we don't need). We should make it easier to specify what weights we _do_ support.

## Purpose ##

Add a property to indicate which weights a font family supports.

## Scope ##

* Add `supportedWeights` property to `FontFamily` protocol
* default implementation is to return all weights
* revise `accessibilityWeight(for:)` func to iterate through supported weights and return the next heavier weight (if any), otherwise returns the heaviest weight
* unit tests for new functionality

## 📈 Coverage ##

##### Code: 99.9% #####

<img width="672" alt="image" src="https://user-images.githubusercontent.com/1037520/191989706-135646f0-a9d5-4881-a110-03e30e879b84.png">

##### Documentation: 100% #####

<img width="544" alt="image" src="https://user-images.githubusercontent.com/1037520/191989939-7e7996cf-8955-4629-9983-c583e5ce620b.png">
