### PR TITLE
Add tvOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let package = Package(
     name: "YMatterType",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v14)
+        .iOS(.v14),
+        .tvOS(.v14)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Y-Matter Type](https://mpospese.com/wp-content/uploads/2022/08/YMatterType-hero-compact.jpeg)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyml-org%2FYMatterType%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/yml-org/YMatterType) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyml-org%2FYMatterType%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/yml-org/YMatterType)  
-_An opinionated take on Design System Typography for iOS._
+_An opinionated take on Design System Typography for iOS and tvOS._
 
 This framework uses Figma's concept of Typography to create text-based UI elements (labels, buttons, text fields, and text views) that render themselves as described in Figma design files (especially sizing themselves according to line height) while also supporting Dynamic Type scaling and the Bold Text accessibility setting.
 
@@ -17,7 +17,7 @@ Documentation is automatically generated from source code comments and rendered 
 
 ## What is Y—MatterType?
 
-Y—MatterType is a framework that assists in getting typography done right when constructing iOS user interfaces from Figma-based designs.
+Y—MatterType is a framework that assists in getting typography done right when constructing iOS and tvOS user interfaces from Figma-based designs.
 
 Y—MatterType aims to achieve the following goals:
 

--- a/Sources/YMatterType/Elements/TypographyButton.swift
+++ b/Sources/YMatterType/Elements/TypographyButton.swift
@@ -13,14 +13,14 @@ import UIKit
 open class TypographyButton: UIButton {
     /// The current typographical layout
     public private(set) var layout: TypographyLayout!
-    
+
     /// Typography to be used for this buttons's title label
     public var typography: Typography {
         didSet {
             adjustFonts()
         }
     }
-    
+
     /// (Optional) maximum point size when scaling the font.
     ///
     /// Value should be greater than Typography.fontSize.
@@ -61,7 +61,7 @@ open class TypographyButton: UIButton {
         super.init(frame: .zero)
         build()
     }
-    
+
     /// :nodoc:
     required public init?(coder: NSCoder) { nil }
 
@@ -69,7 +69,7 @@ open class TypographyButton: UIButton {
         case text
         case attributedText
     }
-    
+
     private var textSetMode: TextSetMode = .text
 
     /// :nodoc:
@@ -79,7 +79,7 @@ open class TypographyButton: UIButton {
         textSetMode = .text
         styleText(title, for: state)
     }
-    
+
     /// :nodoc:
     override public func setAttributedTitle(_ title: NSAttributedString?, for state: UIControl.State) {
         // When text is set, we may need to re-style it as attributedText
@@ -87,7 +87,7 @@ open class TypographyButton: UIButton {
         textSetMode = .attributedText
         styleAttributedText(title, for: state)
     }
-    
+
     /// Gets or sets the text alignment of the button's title label.
     /// Default value = `.natural`
     public var textAlignment: NSTextAlignment = .natural {
@@ -99,7 +99,7 @@ open class TypographyButton: UIButton {
             }
         }
     }
-    
+
     /// Gets or sets the line break mode of the button's title label.
     /// Default value = `.byTruncatingTail`
     public var lineBreakMode: NSLineBreakMode = .byTruncatingTail {
@@ -119,7 +119,7 @@ open class TypographyButton: UIButton {
         if traitCollection.hasDifferentFontAppearance(comparedTo: previousTraitCollection) {
             adjustFonts()
         }
-        
+
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
             adjustColors()
         }
@@ -212,16 +212,16 @@ private extension TypographyButton {
         adjustColors()
         adjustBreakpoint()
     }
-    
+
     func configure() {
         setTitleColor(.label, for: .normal)
         titleLabel?.adjustsFontForContentSizeCategory = true
     }
-    
+
     @objc func contentSizeDidChange() {
         adjustFonts()
     }
-    
+
     func restyleText() {
         styleAttributedText(currentAttributedTitle, for: state)
     }
@@ -240,7 +240,7 @@ private extension TypographyButton {
         let attributedText = layout.styleText(newValue, lineMode: lineMode)
         super.setAttributedTitle(attributedText, for: state)
     }
-    
+
     func styleAttributedText(_ newValue: NSAttributedString?, for state: UIControl.State) {
         defer { invalidateIntrinsicContentSize() }
         guard let layout = layout,

--- a/Sources/YMatterType/Elements/TypographyLabel.swift
+++ b/Sources/YMatterType/Elements/TypographyLabel.swift
@@ -20,7 +20,7 @@ open class TypographyLabel: UILabel {
             adjustFonts()
         }
     }
-    
+
     /// (Optional) maximum point size when scaling the font.
     ///
     /// Value should be greater than Typography.fontSize.
@@ -61,7 +61,7 @@ open class TypographyLabel: UILabel {
         super.init(frame: .zero)
         build()
     }
-    
+
     /// :nodoc:
     required public init?(coder: NSCoder) { nil }
 
@@ -69,7 +69,7 @@ open class TypographyLabel: UILabel {
         case text
         case attributedText
     }
-    
+
     private var textSetMode: TextSetMode = .text
 
     /// :nodoc:
@@ -82,7 +82,7 @@ open class TypographyLabel: UILabel {
             styleText(newValue)
         }
     }
-    
+
     /// :nodoc:
     override public var attributedText: NSAttributedString? {
         get { super.attributedText }
@@ -104,7 +104,7 @@ open class TypographyLabel: UILabel {
             }
         }
     }
-    
+
     /// :nodoc:
     override public var lineBreakMode: NSLineBreakMode {
         didSet {
@@ -123,7 +123,7 @@ open class TypographyLabel: UILabel {
         if traitCollection.hasDifferentFontAppearance(comparedTo: previousTraitCollection) {
             adjustFonts()
         }
-        
+
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
             adjustColors()
         }
@@ -132,7 +132,7 @@ open class TypographyLabel: UILabel {
             adjustBreakpoint()
         }
     }
-    
+
     /// Call this if you've made a change that would require text to be re-styled. (Normally this is not necessary).
     /// Override this if you need to do something additional when preferred content size
     /// or legibility weight has changed
@@ -145,7 +145,7 @@ open class TypographyLabel: UILabel {
         font = layout.font
         restyleText()
     }
-    
+
     /// Override this if you have colors that will not automatically adjust to
     /// Light / Dark mode, etc. This can be the case for CGColor or
     /// non-template images (or backgroundImages).
@@ -167,11 +167,11 @@ private extension TypographyLabel {
         adjustColors()
         adjustBreakpoint()
     }
-    
+
     func configure() {
         adjustsFontForContentSizeCategory = true
     }
-    
+
     func restyleText() {
         if textSetMode == .text {
             styleText(text)
@@ -193,7 +193,7 @@ private extension TypographyLabel {
         // Set attributed text to match typography
         super.attributedText = layout.styleText(newValue, lineMode: lineMode)
     }
-    
+
     func styleAttributedText(_ newValue: NSAttributedString?) {
         defer { invalidateIntrinsicContentSize() }
         guard let layout = layout,

--- a/Sources/YMatterType/Elements/TypographyTextField.swift
+++ b/Sources/YMatterType/Elements/TypographyTextField.swift
@@ -25,8 +25,17 @@ open class TypographyTextField: UITextField {
         }
     }
 
-    /// Insets to apply around the functional area of the `UITextField`. Defaults to `.zero`
-    public var textInsets: UIEdgeInsets = .zero {
+    /// Default text insets (values vary by platform)
+    public static var defaultTextInsets: UIEdgeInsets = {
+#if os(tvOS)
+        UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+#else
+        .zero
+#endif
+    }()
+
+    /// Insets to apply around the functional area of the `UITextField`.
+    public var textInsets: UIEdgeInsets = TypographyTextField.defaultTextInsets {
         didSet {
             if textInsets != oldValue {
                 invalidateIntrinsicContentSize()
@@ -162,12 +171,20 @@ open class TypographyTextField: UITextField {
 
     /// :nodoc
     open override func textRect(forBounds bounds: CGRect) -> CGRect {
+#if os(tvOS)
+        bounds.inset(by: textInsets)
+#else
         super.textRect(forBounds: bounds).inset(by: textInsets)
+#endif
     }
 
     /// :nodoc
     open override func editingRect(forBounds bounds: CGRect) -> CGRect {
+#if os(tvOS)
+        bounds.inset(by: textInsets)
+#else
         super.editingRect(forBounds: bounds).inset(by: textInsets)
+#endif
     }
 
     /// :nodoc

--- a/Sources/YMatterType/Extensions/UIKit/NSParagraphStyle+lineSpacing.swift
+++ b/Sources/YMatterType/Extensions/UIKit/NSParagraphStyle+lineSpacing.swift
@@ -17,7 +17,7 @@ extension NSParagraphStyle {
         paragraphStyle.lineSpacing = lineSpacing
         return paragraphStyle
     }
-    
+
     /// Combines line height multiple with the existing style
     /// - Parameter lineHeightMultiple: the line height multiple to use
     /// - Returns: Current paragraph style combined with line height multiple
@@ -26,7 +26,7 @@ extension NSParagraphStyle {
         paragraphStyle.lineHeightMultiple = lineHeightMultiple
         return paragraphStyle
     }
-    
+
     /// Combines text alignment with the existing style
     /// - Parameter alignment: the text alignment to use
     /// - Returns: Current paragraph style combined with text alignment

--- a/Sources/YMatterType/Typography/FontFamily/DefaultFontFamily.swift
+++ b/Sources/YMatterType/Typography/FontFamily/DefaultFontFamily.swift
@@ -12,13 +12,13 @@ import UIKit
 public struct DefaultFontFamily: FontFamily {
     /// Suffix to use for italic family font names "Italic"
     public static let italicSuffix = "Italic"
-    
+
     /// Font family root name, e.g. "AvenirNext"
     public let familyName: String
-    
+
     /// Font style, e.g. regular or italic
     public let style: Typography.FontStyle
-    
+
     /// Initialize a `DefaultFontFamily` object
     /// - Parameters:
     ///   - familyName: font family name
@@ -27,7 +27,7 @@ public struct DefaultFontFamily: FontFamily {
         self.familyName = familyName
         self.style = style
     }
-    
+
     /// Optional suffix to use for the font name.
     ///
     /// Used by `FontFamily.fontName(for:compatibleWith:)`

--- a/Sources/YMatterType/Typography/FontFamily/FontFamily.swift
+++ b/Sources/YMatterType/Typography/FontFamily/FontFamily.swift
@@ -14,7 +14,7 @@ import os
 public protocol FontFamily {
     /// Font family root name, e.g. "AvenirNext"
     var familyName: String { get }
-    
+
     /// Optional suffix to use for the font name.
     ///
     /// Used by `FontFamily.fontName(for:compatibleWith:)`
@@ -31,7 +31,7 @@ public protocol FontFamily {
 
     // The following four methods have default implementations that
     // can be overridden in custom implementations of `FontFamily`.
-    
+
     /// Returns a font for the specified `weight` and `pointSize` that is compatible with the `traitCollection`
     /// - Parameters:
     ///   - weight: desired font weight
@@ -50,12 +50,12 @@ public protocol FontFamily {
     /// If `nil` then `UIAccessibility.isBoldTextEnabled` will be considered instead
     /// - Returns: The font name formulated from `familyName` and `weight`
     func fontName(for weight: Typography.FontWeight, compatibleWith traitCollection: UITraitCollection?) -> String
-    
+
     /// Generates a weight name suffix as part of a full font name. Not all fonts support all 9 weights.
     /// - Parameter weight: desired font weight
     /// - Returns: The weight name to use
     func weightName(for weight: Typography.FontWeight) -> String
-    
+
     /// Returns the alternate weight to use if user has requested a bold font. e.g. might convert `.regular`
     /// to `.semibold`. Not all fonts support all 9 weights.
     /// - Parameter weight: desired font weight
@@ -94,7 +94,7 @@ extension FontFamily {
         }
         return font
     }
-    
+
     public func fontName(
         for weight: Typography.FontWeight,
         compatibleWith traitCollection: UITraitCollection?
@@ -105,7 +105,7 @@ extension FontFamily {
         let weightName = weightName(for: actualWeight)
         return "\(familyName)-\(weightName)\(fontNameSuffix)"
     }
-    
+
     public func weightName(for weight: Typography.FontWeight) -> String {
         // Default font name suffix by weight
         switch weight {
@@ -129,7 +129,7 @@ extension FontFamily {
             return "Black"
         }
     }
-    
+
     public func accessibilityBoldWeight(for weight: Typography.FontWeight) -> Typography.FontWeight {
         // By default returns the next heavier supported weight (if any), otherwise the heaviest supported weight
         let weights = supportedWeights.sorted(by: { $0.rawValue < $1.rawValue })
@@ -147,7 +147,7 @@ extension FontFamily {
         guard let traitCollection = traitCollection else {
             return UIAccessibility.isBoldTextEnabled
         }
-        
+
         return traitCollection.legibilityWeight == .bold
     }
 }

--- a/Sources/YMatterType/Typography/FontFamily/SystemFontFamily.swift
+++ b/Sources/YMatterType/Typography/FontFamily/SystemFontFamily.swift
@@ -52,7 +52,7 @@ public struct SystemFontFamily: FontFamily {
     // The system font has a private font family name (literally ".SFUI"), so
     // just return empty string for familyName. The system font can't be retrieved by name anyway.
     public var familyName: String { "" }
-    
+
     /// Returns a font for the specified `weight` and `pointSize` that is compatible with the `traitCollection`
     /// - Parameters:
     ///   - weight: desired font weight

--- a/Sources/YMatterType/Typography/Typography+System.swift
+++ b/Sources/YMatterType/Typography/Typography+System.swift
@@ -14,20 +14,24 @@ extension Typography {
 
     /// Standard typography for labels (uses the system font)
     public static let systemLabel = makeSystemTypography(
-        fontSize: UIFont.labelFontSize, weight: .regular, textStyle: .body
+        fontSize: labelFontSize, weight: labelFontWeight, textStyle: .body
     )
 
     /// Standard typography for buttons (uses the system font)
     public static let systemButton = makeSystemTypography(
-        fontSize: UIFont.buttonFontSize, weight: .medium, textStyle: .subheadline
+        fontSize: buttonFontSize, weight: buttonFontWeight, textStyle: .subheadline
     )
 
     /// Typography for the system font
+    @available(iOS 14, *)
+    @available(tvOS, unavailable)
     public static let system = makeSystemTypography(
         fontSize: UIFont.systemFontSize, weight: .regular, textStyle: .callout
     )
 
     /// Typography for the small system font
+    @available(iOS 14, *)
+    @available(tvOS, unavailable)
     public static let smallSystem = makeSystemTypography(
         fontSize: UIFont.smallSystemFontSize, weight: .regular, textStyle: .footnote
     )
@@ -46,4 +50,16 @@ extension Typography {
             textStyle: textStyle
         )
     }
+
+#if os(tvOS)
+    static var labelFontSize: CGFloat { 38.0 }
+    static var labelFontWeight: FontWeight { .medium }
+    static var buttonFontSize: CGFloat { 38.0 }
+    static var buttonFontWeight: FontWeight { .medium }
+#else
+    static var labelFontSize: CGFloat { UIFont.labelFontSize }
+    static var labelFontWeight: FontWeight { .regular }
+    static var buttonFontSize: CGFloat { UIFont.buttonFontSize }
+    static var buttonFontWeight: FontWeight { .regular }
+#endif
 }

--- a/Sources/YMatterType/Typography/Typography.swift
+++ b/Sources/YMatterType/Typography/Typography.swift
@@ -80,7 +80,7 @@ public struct Typography {
         self.textStyle = textStyle
         self.isFixed = isFixed
     }
-    
+
     /// Initializes a typography instance with the specified parameters
     /// - Parameters:
     ///   - familyName: font family name

--- a/Sources/YMatterType/Typography/TypographyLayout.swift
+++ b/Sources/YMatterType/Typography/TypographyLayout.swift
@@ -14,7 +14,7 @@ import UIKit
 public struct TypographyLayout {
     /// Font to use (potentially scaled and considering Accessibility Bold Text)
     public let font: UIFont
-    
+
     /// Scaled line height to use with this font
     public let lineHeight: CGFloat
 
@@ -29,7 +29,7 @@ public struct TypographyLayout {
 
     /// Paragraph spacing to apply
     public let paragraphSpacing: CGFloat
-    
+
     /// Text case to apply to text
     public let textCase: Typography.TextCase
 

--- a/Tests/YMatterTypeTests/Elements/ElementFontAdjustedTests.swift
+++ b/Tests/YMatterTypeTests/Elements/ElementFontAdjustedTests.swift
@@ -24,7 +24,7 @@ final class ElementFontAdjustedTests: XCTestCase {
         fontWeight: .heavy,
         fontSize: 32,
         lineHeight: 40,
-        textStyle: .largeTitle,
+        textStyle: .title1,
         isFixed: true
     )
     

--- a/Tests/YMatterTypeTests/Elements/TypographyButtonTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyButtonTests.swift
@@ -151,7 +151,7 @@ final class TypographyButtonTests: TypographyElementTests {
             sut.typography.lineHeight * 2 + sut.contentEdgeInsets.vertical
         )
 
-        let fontFamily = DefaultFontFamily(familyName: "Verdana")
+        let fontFamily = DefaultFontFamily(familyName: "AvenirNext")
         let typography = Typography(
             fontFamily: fontFamily,
             fontWeight: .bold,
@@ -174,7 +174,7 @@ final class TypographyButtonTests: TypographyElementTests {
         // we expect a font
         XCTAssertNotNil(sut.layout?.font)
         // we expect the font to have the new family
-        XCTAssertEqual(sut.layout?.font.familyName, typography.fontFamily.familyName)
+        XCTAssertEqual(sut.layout?.font.familyName.removeSpaces(), typography.fontFamily.familyName)
         // we expect label height to be a multiple of the new lineHeight
         XCTAssertEqual(
             sut.intrinsicContentSize.height,
@@ -182,6 +182,7 @@ final class TypographyButtonTests: TypographyElementTests {
         )
     }
 
+#if os(iOS)
     func testMaximumPointSize() {
         let sut = makeSUT()
         let fontFamily = DefaultFontFamily(familyName: "Menlo")
@@ -272,6 +273,7 @@ final class TypographyButtonTests: TypographyElementTests {
             )
         }
     }
+#endif
 
     func testSetText() {
         let sut = makeSUT()

--- a/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
@@ -135,7 +135,7 @@ final class TypographyLabelTests: TypographyElementTests {
         // we expect label height to be a multiple of the old lineHeight
         XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight * 2)
 
-        let fontFamily = DefaultFontFamily(familyName: "Verdana")
+        let fontFamily = DefaultFontFamily(familyName: "AvenirNext")
         let typography = Typography(
             fontFamily: fontFamily,
             fontWeight: .bold,
@@ -156,11 +156,12 @@ final class TypographyLabelTests: TypographyElementTests {
         // we expect a font
         XCTAssertNotNil(sut.font)
         // we expect the font to have the new family
-        XCTAssertEqual(sut.font.familyName, typography.fontFamily.familyName)
+        XCTAssertEqual(sut.font.familyName.removeSpaces(), typography.fontFamily.familyName)
         // we expect label height to be a multiple of the new lineHeight
         XCTAssertEqual(sut.intrinsicContentSize.height, typography.lineHeight * 2)
     }
     
+#if os(iOS)
     func testMaximumPointSize() {
         let sut = makeSUT()
         let fontFamily = DefaultFontFamily(familyName: "Menlo")
@@ -243,7 +244,8 @@ final class TypographyLabelTests: TypographyElementTests {
             XCTAssertEqual(sut.intrinsicContentSize.height, $0 * scaledType.lineHeight * 2)
         }
     }
-
+#endif
+    
     func testSetText() {
         let sut = makeSUT()
         // Given a label with 2 lines of text

--- a/Tests/YMatterTypeTests/Elements/TypographyTextFieldTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyTextFieldTests.swift
@@ -74,7 +74,7 @@ final class TypographyTextFieldTests: TypographyElementTests {
         // we expect text field height to equal the old lineHeight
         XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight)
 
-        let fontFamily = DefaultFontFamily(familyName: "Verdana")
+        let fontFamily = DefaultFontFamily(familyName: "AvenirNext")
         let typography = Typography(
             fontFamily: fontFamily,
             fontWeight: .bold,
@@ -95,11 +95,12 @@ final class TypographyTextFieldTests: TypographyElementTests {
         // we expect a font
         XCTAssertNotNil(sut.font)
         // we expect the font to have the new family
-        XCTAssertEqual(sut.font?.familyName, typography.fontFamily.familyName)
+        XCTAssertEqual(sut.font?.familyName.removeSpaces(), typography.fontFamily.familyName)
         // we expect text field height to equal the new lineHeight
         XCTAssertEqual(sut.intrinsicContentSize.height, typography.lineHeight)
     }
 
+#if os(iOS)
     func testMaximumPointSize() {
         let sut = makeSUT()
         let scaledType = Typography.body
@@ -166,7 +167,8 @@ final class TypographyTextFieldTests: TypographyElementTests {
             XCTAssertEqual(sut.intrinsicContentSize.height, $0 * scaledType.lineHeight)
         }
     }
-
+#endif
+    
     func testSetText() {
         let sut = makeSUT()
         // Given a text field
@@ -200,7 +202,7 @@ final class TypographyTextFieldTests: TypographyElementTests {
         XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight)
 
         // changing the typograhy will restyle the attributed text
-        let fontFamily = DefaultFontFamily(familyName: "Verdana")
+        let fontFamily = DefaultFontFamily(familyName: "AvenirNext")
         sut.typography = Typography(
             fontFamily: fontFamily,
             fontWeight: .bold,
@@ -226,11 +228,14 @@ final class TypographyTextFieldTests: TypographyElementTests {
 
     func testTextInsets() {
         let sut = makeSUT()
+#if os(iOS)
+        // setting placeholder triggers a memory leak on tvOS (true for plain vanilla UITextField)!
         sut.placeholder = "First Name"
+#endif
         sut.text = "John"
 
         // text insets should be zero by default
-        XCTAssertEqual(sut.textInsets, .zero)
+        XCTAssertEqual(sut.textInsets, TypographyTextField.defaultTextInsets)
         XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight)
 
         // but if we apply different text insets, the height should adjust accordingly
@@ -250,6 +255,7 @@ final class TypographyTextFieldTests: TypographyElementTests {
             XCTAssertEqual(sut.editingRect(forBounds: bounds), insetBounds)
             XCTAssertEqual(sut.leftViewRect(forBounds: bounds).minX, insetBounds.minX)
             XCTAssertEqual(sut.rightViewRect(forBounds: bounds).maxX, insetBounds.maxX)
+            XCTAssertEqual(sut.clearButtonRect(forBounds: bounds).maxX, insetBounds.maxX - 5)
         }
     }
 

--- a/Tests/YMatterTypeTests/Elements/TypographyTextViewTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyTextViewTests.swift
@@ -100,7 +100,7 @@ final class TypographyTextViewTests: TypographyElementTests {
         // we expect label height to be a multiple of the old lineHeight
         XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight * 2)
 
-        let fontFamily = DefaultFontFamily(familyName: "Verdana")
+        let fontFamily = DefaultFontFamily(familyName: "AvenirNext")
         let typography = Typography(
             fontFamily: fontFamily,
             fontWeight: .bold,
@@ -121,11 +121,12 @@ final class TypographyTextViewTests: TypographyElementTests {
         // we expect a font
         XCTAssertNotNil(sut.font)
         // we expect the font to have the new family
-        XCTAssertEqual(sut.font?.familyName, typography.fontFamily.familyName)
+        XCTAssertEqual(sut.font?.familyName.removeSpaces(), typography.fontFamily.familyName)
         // we expect label height to be a multiple of the new lineHeight
         XCTAssertEqual(sut.intrinsicContentSize.height, typography.lineHeight * 2)
     }
 
+#if os(iOS)
     func testMaximumPointSize() {
         let sut = makeSUT()
         let fontFamily = DefaultFontFamily(familyName: "Menlo")
@@ -206,7 +207,8 @@ final class TypographyTextViewTests: TypographyElementTests {
             XCTAssertEqual(sut.intrinsicContentSize.height, $0 * scaledType.lineHeight * 2)
         }
     }
-
+#endif
+    
     func testSetText() {
         let sut = makeSUT()
         // Given a text view with 2 lines of text

--- a/Tests/YMatterTypeTests/Extensions/Foundation/NSAttributedString+textCaseTests.swift
+++ b/Tests/YMatterTypeTests/Extensions/Foundation/NSAttributedString+textCaseTests.swift
@@ -110,7 +110,7 @@ private extension NSAttributedStringTextCaseTests {
         case .sentence:
             return [
                 .foregroundColor: UIColor.systemRed,
-                .backgroundColor: UIColor.systemBackground
+                .backgroundColor: UIColor.systemTeal
             ]
         case .asymmetric:
             return [.paragraphStyle: NSParagraphStyle.default.styleWithLineHeight(24)]

--- a/Tests/YMatterTypeTests/Extensions/UIKit/UITraitCollection+traits.swift
+++ b/Tests/YMatterTypeTests/Extensions/UIKit/UITraitCollection+traits.swift
@@ -18,15 +18,18 @@ extension UITraitCollection {
     // Traits affecting a variety of things but not Dynamic Type Size or Bold Text
     static func generateSimilarFontTraits(to startingTraits: UITraitCollection) -> [UITraitCollection] {
         // return each of these traits combined with startingTraits
-        [
+        var traits = [
             UITraitCollection(horizontalSizeClass: .compact),
             UITraitCollection(verticalSizeClass: .compact),
             UITraitCollection(userInterfaceIdiom: .pad),
             UITraitCollection(userInterfaceStyle: .dark),
             UITraitCollection(displayGamut: .P3),
-            UITraitCollection(accessibilityContrast: .high),
-            UITraitCollection(userInterfaceLevel: .elevated)
-        ].map({ UITraitCollection(traitsFrom: [startingTraits, $0]) })
+            UITraitCollection(accessibilityContrast: .high)
+            ]
+#if os(iOS)
+        traits.append(UITraitCollection(userInterfaceLevel: .elevated))
+#endif
+        return traits.map({ UITraitCollection(traitsFrom: [startingTraits, $0]) })
     }
 
     // Traits with different values for Dynamic Type Size or Bold Text
@@ -63,13 +66,20 @@ extension UITraitCollection {
     // userInterfaceIdiom, userInterfaceStyle, displayGamut, accessibilityContrast, userInterfaceLevel
     // and more could be added in the future.
 
-    static let startingColorTraits = UITraitCollection(traitsFrom: [
-        UITraitCollection(userInterfaceIdiom: .phone),
-        UITraitCollection(userInterfaceStyle: .light),
-        UITraitCollection(displayGamut: .SRGB),
-        UITraitCollection(accessibilityContrast: .normal),
-        UITraitCollection(userInterfaceLevel: .base)
-    ])
+    static let startingColorTraits: UITraitCollection = {
+        var traits = [
+            UITraitCollection(userInterfaceIdiom: .phone),
+            UITraitCollection(userInterfaceStyle: .light),
+            UITraitCollection(displayGamut: .SRGB),
+            UITraitCollection(accessibilityContrast: .normal)
+            ]
+
+#if os(iOS)
+        traits.append(UITraitCollection(userInterfaceLevel: .base))
+#endif
+
+        return UITraitCollection(traitsFrom: traits)
+    }()
 
     // Traits affecting a variety of things but not anything that could change color appearance
     static func generateSimilarColorTraits(to startingTraits: UITraitCollection) -> [UITraitCollection] {
@@ -84,49 +94,56 @@ extension UITraitCollection {
 
     // Traits with different values for traits that could affect color
     static func generateDifferentColorTraits() -> [UITraitCollection] {
-        [
+        var traits = [
             UITraitCollection(),
             UITraitCollection(traitsFrom: [
                 UITraitCollection(userInterfaceIdiom: .pad),
                 UITraitCollection(userInterfaceStyle: .light),
                 UITraitCollection(displayGamut: .SRGB),
-                UITraitCollection(accessibilityContrast: .normal),
-                UITraitCollection(userInterfaceLevel: .base)
+                UITraitCollection(accessibilityContrast: .normal)
             ]),
             UITraitCollection(traitsFrom: [
                 UITraitCollection(userInterfaceIdiom: .phone),
                 UITraitCollection(userInterfaceStyle: .dark),
                 UITraitCollection(displayGamut: .SRGB),
-                UITraitCollection(accessibilityContrast: .normal),
-                UITraitCollection(userInterfaceLevel: .base)
+                UITraitCollection(accessibilityContrast: .normal)
             ]),
             UITraitCollection(traitsFrom: [
                 UITraitCollection(userInterfaceIdiom: .phone),
                 UITraitCollection(userInterfaceStyle: .light),
                 UITraitCollection(displayGamut: .P3),
-                UITraitCollection(accessibilityContrast: .normal),
-                UITraitCollection(userInterfaceLevel: .base)
+                UITraitCollection(accessibilityContrast: .normal)
             ]),
             UITraitCollection(traitsFrom: [
                 UITraitCollection(userInterfaceIdiom: .phone),
                 UITraitCollection(userInterfaceStyle: .light),
                 UITraitCollection(displayGamut: .SRGB),
-                UITraitCollection(accessibilityContrast: .high),
-                UITraitCollection(userInterfaceLevel: .base)
-            ]),
-            UITraitCollection(traitsFrom: [
-                UITraitCollection(userInterfaceIdiom: .phone),
-                UITraitCollection(userInterfaceStyle: .light),
-                UITraitCollection(displayGamut: .SRGB),
-                UITraitCollection(accessibilityContrast: .normal),
-                UITraitCollection(userInterfaceLevel: .elevated)
+                UITraitCollection(accessibilityContrast: .high)
             ]),
             UITraitCollection(userInterfaceIdiom: .tv),
             UITraitCollection(userInterfaceStyle: .dark),
             UITraitCollection(displayGamut: .P3),
-            UITraitCollection(accessibilityContrast: .high),
-            UITraitCollection(userInterfaceLevel: .elevated)
+            UITraitCollection(accessibilityContrast: .high)
         ]
+
+#if os(iOS)
+        traits.append(
+            contentsOf: [
+                UITraitCollection(
+                    traitsFrom: [
+                        UITraitCollection(userInterfaceIdiom: .phone),
+                        UITraitCollection(userInterfaceStyle: .light),
+                        UITraitCollection(displayGamut: .SRGB),
+                        UITraitCollection(accessibilityContrast: .normal),
+                        UITraitCollection(userInterfaceLevel: .elevated)
+                    ]
+                ),
+                UITraitCollection(userInterfaceLevel: .elevated)
+            ]
+        )
+#endif
+
+        return traits
     }
 
     // MARK: - Breakpoints
@@ -139,15 +156,18 @@ extension UITraitCollection {
     // Traits affecting a variety of things but not horizontal or vertical size class
     static func generateSimilarBreakpointTraits(to startingTraits: UITraitCollection) -> [UITraitCollection] {
         // return each of these traits combined with startingTraits
-        [
+        var traits = [
             UITraitCollection(preferredContentSizeCategory: .accessibilityMedium),
             UITraitCollection(legibilityWeight: .bold),
             UITraitCollection(userInterfaceIdiom: .pad),
             UITraitCollection(userInterfaceStyle: .dark),
             UITraitCollection(displayGamut: .P3),
-            UITraitCollection(accessibilityContrast: .high),
-            UITraitCollection(userInterfaceLevel: .elevated)
-        ].map({ UITraitCollection(traitsFrom: [startingTraits, $0]) })
+            UITraitCollection(accessibilityContrast: .high)
+        ]
+#if os(iOS)
+        traits.append(UITraitCollection(userInterfaceLevel: .elevated))
+#endif
+        return traits.map({ UITraitCollection(traitsFrom: [startingTraits, $0]) })
     }
 
     // Traits with different values for traits that could affect breakpoints

--- a/Tests/YMatterTypeTests/Helpers/Typography+YMatterTypeTests.swift
+++ b/Tests/YMatterTypeTests/Helpers/Typography+YMatterTypeTests.swift
@@ -9,6 +9,7 @@
 import YMatterType
 
 extension Typography {
+#if !os(tvOS)
     /// SF Pro Display, Semibold 32/36 pts
     static let largeTitle = Typography(
         fontFamily: Typography.systemFamily,
@@ -17,6 +18,7 @@ extension Typography {
         lineHeight: 36,
         textStyle: .largeTitle
     )
+#endif
 
     /// SF Pro Display, Semibold 28/34 pts
     static let title1 = Typography(

--- a/Tests/YMatterTypeTests/Typography/Typography+FontTests.swift
+++ b/Tests/YMatterTypeTests/Typography/Typography+FontTests.swift
@@ -65,6 +65,7 @@ final class TypographyFontTests: XCTestCase {
         }
     }
 
+#if os(iOS)
     func testMaximumPointSize() {
         let fontFamily = DefaultFontFamily(familyName: "Menlo")
         let traits = UITraitCollection(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge)
@@ -155,6 +156,7 @@ final class TypographyFontTests: XCTestCase {
             XCTAssertEqual(layout.baselineOffset.ceiled(), layout.baselineOffset)
         }
     }
+#endif
 }
 
 struct AppleSDGothicNeoInfo: FontFamily {

--- a/Tests/YMatterTypeTests/Typography/Typography+MutatorsTests.swift
+++ b/Tests/YMatterTypeTests/Typography/Typography+MutatorsTests.swift
@@ -10,17 +10,22 @@ import XCTest
 @testable import YMatterType
 
 final class TypographyMutatorsTests: XCTestCase {
-    private let types: [Typography] = [
-        .largeTitle,
-        .title1,
-        .title2,
-        .headline,
-        .subhead,
-        .body,
-        .bodyBold,
-        .smallBody,
-        .smallBodyBold
-    ]
+    private let types: [Typography] = {
+        var styles: [Typography] = [
+            .title1,
+            .title2,
+            .headline,
+            .subhead,
+            .body,
+            .bodyBold,
+            .smallBody,
+            .smallBodyBold
+        ]
+#if !os(tvOS)
+        styles.insert(.largeTitle, at: 0)
+#endif
+        return styles
+    }()
 
     func testRegular() {
         types.forEach {

--- a/Tests/YMatterTypeTests/Typography/Typography+SystemTests.swift
+++ b/Tests/YMatterTypeTests/Typography/Typography+SystemTests.swift
@@ -12,26 +12,33 @@ import XCTest
 final class TypographySystemTests: XCTestCase {
     func testSystemLabel() {
         let sut = Typography.systemLabel
-        XCTAssertEqual(sut.fontSize, UIFont.labelFontSize)
+        XCTAssertEqual(sut.fontSize, Typography.labelFontSize)
+        XCTAssertEqual(sut.fontWeight, Typography.labelFontWeight)
         _testLineHeight(sut: sut)
     }
 
     func testSystemButton() {
         let sut = Typography.systemButton
-        XCTAssertEqual(sut.fontSize, UIFont.buttonFontSize)
+        XCTAssertEqual(sut.fontSize, Typography.buttonFontSize)
+        XCTAssertEqual(sut.fontWeight, Typography.buttonFontWeight)
         _testLineHeight(sut: sut)
     }
 
+#if !os(tvOS)
     func testSystem() {
         let sut = Typography.system
         XCTAssertEqual(sut.fontSize, UIFont.systemFontSize)
+        XCTAssertEqual(sut.fontWeight, .regular)
         _testLineHeight(sut: sut)
     }
 
     func testSmallSystem() {
         let sut = Typography.smallSystem
+        XCTAssertEqual(sut.fontSize, UIFont.smallSystemFontSize)
+        XCTAssertEqual(sut.fontWeight, .regular)
         _testLineHeight(sut: sut)
     }
+#endif
 
     private func _testLineHeight(sut: Typography) {
         XCTAssertEqual(sut.lineHeight, ceil(sut.fontSize * Typography.systemLineHeightMultiple))


### PR DESCRIPTION
## Introduction ##

If we're building tvOS apps with UIKit, we could use YMatterType to add accessibility features.

## Purpose ##

Add tvOS support

## Scope ##

* Exclude functionality that does not compile for tvOS
* Exclude tests for Dynamic Type changes (not currently supported on iOS)
* Modify tests to use fonts available on both iOS and tvOS platforms
* Fix linter whitespace warnings

## Discussion ##

* tvOS does not currently support Dynamic Type scaling (even though at the compiler level it does)
* tvOS has some different behaviors around `UITextField` that needed to be accounted for
* tvOS includes a different (smaller) list of fonts than iOS
* not sure why the linter decided to complain about whitespace on otherwise empty lines. New version of SwiftLint?

## 📈 Coverage ##

##### Code: 99.9% #####

<img width="621" alt="image" src="https://user-images.githubusercontent.com/1037520/192577316-c3a1b339-4a9d-4310-ba26-4cc891c83fa0.png">

##### Documentation: 100% #####

<img width="544" alt="image" src="https://user-images.githubusercontent.com/1037520/192577175-fb59abac-8afe-466c-9aa9-eeb7310a2bc3.png">