### PR TITLE
Fix typo in Typography initializers

### DIFF
--- a/Sources/YMatterType/Typography/Typography.swift
+++ b/Sources/YMatterType/Typography/Typography.swift
@@ -48,7 +48,7 @@ public struct Typography {
     ///   - fontWeight: font weight to use
     ///   - fontSize: font size to use
     ///   - lineHeight: line height to use
-    ///   - chaacterSpacing: letter spacing to use (defaults to `0`)
+    ///   - letterSpacing: letter spacing to use (defaults to `0`)
     ///   - paragraphIndent: paragraph indent to use (defaults to `0`)
     ///   - paragraphSpacing: paragraph spacing to use (defaults to `0`)
     ///   - textCase: text case to apply (defaults to `.none`)
@@ -88,7 +88,7 @@ public struct Typography {
     ///   - fontWeight: font weight to use
     ///   - fontSize: font size to use
     ///   - lineHeight: line height to use
-    ///   - chaacterSpacing: letter spacing to use (defaults to `0`)
+    ///   - letterSpacing: letter spacing to use (defaults to `0`)
     ///   - paragraphIndent: paragraph indent to use (defaults to `0`)
     ///   - paragraphSpacing: paragraph spacing to use (defaults to `0`)
     ///   - textCase: text case to apply (defaults to `.none`)


### PR DESCRIPTION
## Introduction ##

Fixed typo in documentation comments for both of the Typography initializers.

## Purpose ##

This fix is to prevent misinformation to the reader  https://github.com/yml-org/YMatterType/issues/15 

## Scope ##

old text -> ///   - chaacterSpacing: letter spacing to use (defaults to `0`)
new text -> ///   - letterSpacing: letter spacing to use (defaults to `0`)

// Optional sections

## Discussion ##

Any discussion about approach, challenges, etc. that you feel is relevant.

## Out of Scope ##

Call out any known issues that are purposely not addressed in this pull request.

## 📱 Screenshots ##

For UI work, please include before/after screenshots hosted in a 2-column table for easy side-by-side comparison.

## 🎬 Video ##

Same as Screenshots above.

## 📈 Coverage ##

##### Code #####

<img width="573" alt="swiftlint-issue-15" src="https://user-images.githubusercontent.com/2257885/193913370-8f7431aa-d942-4df5-abc6-ad7e48882bb2.png">

##### Documentation #####

<img width="563" alt="jazzy-issue-15" src="https://user-images.githubusercontent.com/2257885/193913925-a354f165-c558-4bda-a8c9-35eaa9a457a4.png">
