### PR TITLE
[CM-915] Add IB support to the TypographyLabel

### DIFF
--- a/Sources/YMatterType/Elements/TypographyLabel.swift
+++ b/Sources/YMatterType/Elements/TypographyLabel.swift
@@ -10,15 +10,41 @@ import UIKit
 
 /// A text label that supports `Typography`.
 /// You can optionally set `maximumPointSize` or `maximumScaleFactor` to set a cap on Dynamic Type scaling.
-open class TypographyLabel: UILabel {
+@IBDesignable open class TypographyLabel: UILabel {
+    
     /// The current typographical layout
     public private(set) var layout: TypographyLayout!
-
+    
     /// Typography to be used for this label's text
     public var typography: Typography {
         didSet {
             adjustFonts()
         }
+    }
+    
+    @IBInspectable var familyName: String {
+        get { typography.fontFamily.familyName }
+        set { typography = typography.familyName(newValue) }
+    }
+    
+    @IBInspectable var fontWeight: CGFloat {
+        get { typography.fontWeight.rawValue }
+        set { typography = typography.fontWeight(Typography.FontWeight(rawValue: newValue) ?? .regular) }
+    }
+    
+    @IBInspectable var fontSize: CGFloat {
+        get { typography.fontSize }
+        set { typography = typography.fontSize(newValue) }
+    }
+    
+    @IBInspectable var lineHeight: CGFloat {
+        get { typography.lineHeight }
+        set { typography = typography.lineHeight(newValue) }
+    }
+    
+    @IBInspectable var letterSpacing: CGFloat {
+        get { typography.letterSpacing }
+        set { typography = typography.letterSpacing(newValue) }
     }
 
     /// (Optional) maximum point size when scaling the font.
@@ -36,6 +62,10 @@ open class TypographyLabel: UILabel {
                 adjustFonts()
             }
         }
+    }
+    
+    open override class func prepareForInterfaceBuilder() {
+
     }
 
     /// (Optional) maximum scale factor to use when scaling the font.

--- a/Sources/YMatterType/Elements/TypographyLabel.swift
+++ b/Sources/YMatterType/Elements/TypographyLabel.swift
@@ -22,7 +22,7 @@ open class TypographyLabel: UILabel {
         }
     }
     
-    /// The typography's familyName
+    /// The typography's family name
     ///
     /// Intended for use from Interface Builder only. From code you should just use `typography` directly.
     @IBInspectable

--- a/Sources/YMatterType/Elements/TypographyLabel.swift
+++ b/Sources/YMatterType/Elements/TypographyLabel.swift
@@ -10,8 +10,8 @@ import UIKit
 
 /// A text label that supports `Typography`.
 /// You can optionally set `maximumPointSize` or `maximumScaleFactor` to set a cap on Dynamic Type scaling.
-@IBDesignable open class TypographyLabel: UILabel {
-    
+@IBDesignable
+open class TypographyLabel: UILabel {
     /// The current typographical layout
     public private(set) var layout: TypographyLayout!
     
@@ -22,27 +22,37 @@ import UIKit
         }
     }
     
-    @IBInspectable var familyName: String {
+    /// The familyName attribute
+    @IBInspectable
+    public var familyName: String {
         get { typography.fontFamily.familyName }
         set { typography = typography.familyName(newValue) }
     }
     
-    @IBInspectable var fontWeight: CGFloat {
+    /// The fontWeight attribute
+    @IBInspectable
+    public var fontWeight: CGFloat {
         get { typography.fontWeight.rawValue }
         set { typography = typography.fontWeight(Typography.FontWeight(rawValue: newValue) ?? .regular) }
     }
     
-    @IBInspectable var fontSize: CGFloat {
+    /// The fontSize attribute
+    @IBInspectable
+    public var fontSize: CGFloat {
         get { typography.fontSize }
         set { typography = typography.fontSize(newValue) }
     }
     
-    @IBInspectable var lineHeight: CGFloat {
+    /// The lineHeight attribute
+    @IBInspectable
+    public var lineHeight: CGFloat {
         get { typography.lineHeight }
         set { typography = typography.lineHeight(newValue) }
     }
     
-    @IBInspectable var letterSpacing: CGFloat {
+    /// The letterSpacing attribute
+    @IBInspectable
+    public var letterSpacing: CGFloat {
         get { typography.letterSpacing }
         set { typography = typography.letterSpacing(newValue) }
     }
@@ -62,10 +72,6 @@ import UIKit
                 adjustFonts()
             }
         }
-    }
-    
-    open override class func prepareForInterfaceBuilder() {
-
     }
 
     /// (Optional) maximum scale factor to use when scaling the font.

--- a/Sources/YMatterType/Elements/TypographyLabel.swift
+++ b/Sources/YMatterType/Elements/TypographyLabel.swift
@@ -22,35 +22,45 @@ open class TypographyLabel: UILabel {
         }
     }
     
-    /// The familyName attribute
+    /// The typography's familyName
+    ///
+    /// Intended for use from Interface Builder only. From code you should just use `typography` directly.
     @IBInspectable
     public var familyName: String {
         get { typography.fontFamily.familyName }
         set { typography = typography.familyName(newValue) }
     }
     
-    /// The fontWeight attribute
+    /// The typography's font weight (100 - 900)
+    ///
+    /// Intended for use from Interface Builder only. From code you should just use `typography` directly.
     @IBInspectable
     public var fontWeight: CGFloat {
         get { typography.fontWeight.rawValue }
         set { typography = typography.fontWeight(Typography.FontWeight(rawValue: newValue) ?? .regular) }
     }
     
-    /// The fontSize attribute
+    /// The typography's font size (typically should be less than line height)
+    ///
+    /// Intended for use from Interface Builder only. From code you should just use `typography` directly.
     @IBInspectable
     public var fontSize: CGFloat {
         get { typography.fontSize }
         set { typography = typography.fontSize(newValue) }
     }
     
-    /// The lineHeight attribute
+    /// The typography's line height (typically should be greater than font size)
+    ///
+    /// Intended for use from Interface Builder only. From code you should just use `typography` directly.
     @IBInspectable
     public var lineHeight: CGFloat {
         get { typography.lineHeight }
         set { typography = typography.lineHeight(newValue) }
     }
     
-    /// The letterSpacing attribute
+    /// The typography's letter spacing (kerning)
+    ///
+    /// Intended for use from Interface Builder only. From code you should just use `typography` directly.
     @IBInspectable
     public var letterSpacing: CGFloat {
         get { typography.letterSpacing }

--- a/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
@@ -389,9 +389,6 @@ final class TypographyLabelTests: TypographyElementTests {
         sut.letterSpacing = 5
         XCTAssertEqual(sut.letterSpacing, 5)
     }
-    
-    
-    
 }
 
 private extension TypographyLabelTests {

--- a/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
@@ -354,6 +354,44 @@ final class TypographyLabelTests: TypographyElementTests {
             sut2.intrinsicContentSize.width
         )
     }
+    
+    func testFamilyName() {
+        let sut = makeSUT()
+        XCTAssertEqual(sut.familyName, "NotoSans")
+        sut.familyName = "AppleSDGothicNeo"
+        XCTAssertEqual(sut.familyName, "AppleSDGothicNeo")
+    }
+    
+    func testFontWeight() {
+        let sut = makeSUT()
+        XCTAssertEqual(sut.fontWeight, 400)
+        sut.fontWeight = 700
+        XCTAssertEqual(sut.typography.fontWeight, .bold)
+    }
+    
+    func testFontSize() {
+        let sut = makeSUT()
+        XCTAssertEqual(sut.fontSize, 24)
+        sut.fontSize = 50
+        XCTAssertEqual(sut.fontSize, 50)
+    }
+    
+    func testLineHeight() {
+        let sut = makeSUT()
+        XCTAssertEqual(sut.lineHeight, 32)
+        sut.lineHeight = 40
+        XCTAssertEqual(sut.lineHeight, 40)
+    }
+    
+    func testLetterSpacing() {
+        let sut = makeSUT()
+        XCTAssertEqual(sut.letterSpacing, 0)
+        sut.letterSpacing = 5
+        XCTAssertEqual(sut.letterSpacing, 5)
+    }
+    
+    
+    
 }
 
 private extension TypographyLabelTests {

--- a/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
@@ -9,6 +9,10 @@
 import XCTest
 @testable import YMatterType
 
+// It's not a problem having too many tests!
+// swiftlint:disable file_length
+// swiftlint:disable type_body_length
+
 final class TypographyLabelTests: TypographyElementTests {
     override func setUp() async throws {
         try await super.setUp()

--- a/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
@@ -377,21 +377,21 @@ final class TypographyLabelTests: TypographyElementTests {
         let sut = makeSUT()
         XCTAssertEqual(sut.fontSize, 24)
         sut.fontSize = 50
-        XCTAssertEqual(sut.fontSize, 50)
+        XCTAssertEqual(sut.typography.fontSize, 50)
     }
     
     func testLineHeight() {
         let sut = makeSUT()
         XCTAssertEqual(sut.lineHeight, 32)
         sut.lineHeight = 40
-        XCTAssertEqual(sut.lineHeight, 40)
+        XCTAssertEqual(sut.typography.lineHeight, 40)
     }
     
     func testLetterSpacing() {
         let sut = makeSUT()
         XCTAssertEqual(sut.letterSpacing, 0)
         sut.letterSpacing = 5
-        XCTAssertEqual(sut.letterSpacing, 5)
+        XCTAssertEqual(sut.typography.letterSpacing, 5)
     }
 }
 


### PR DESCRIPTION
## Introduction ##

Added @IBInspectable and @IBDesignable to Typography label

## Purpose ##

It is used to customize the typography properties in Interface Builder

## Scope ##

Added IBInspectable properties in TypographyLabel