### PR TITLE
Update TypographyButton.swift

### DIFF
--- a/Sources/YMatterType/Elements/TypographyButton.swift
+++ b/Sources/YMatterType/Elements/TypographyButton.swift
@@ -200,6 +200,7 @@ open class TypographyButton: UIButton {
         // This should be a no-op, but it's needed to force the attributed title
         // to redraw itself when button state changes
         setTitleColor(currentTitleColor, for: state)
+        adjustFonts()
     }
 }
 

--- a/Sources/YMatterType/Elements/TypographyButton.swift
+++ b/Sources/YMatterType/Elements/TypographyButton.swift
@@ -200,7 +200,7 @@ open class TypographyButton: UIButton {
         // This should be a no-op, but it's needed to force the attributed title
         // to redraw itself when button state changes
         setTitleColor(currentTitleColor, for: state)
-        adjustFonts()
+        restyleText()
     }
 }
 


### PR DESCRIPTION
Fixed button issue

## Introduction ##

Bug fix: Button disabled/highlighted text 

## Purpose ##

To restyle all button title text not just the text for the current state but for all the button state changes. 
e.g. If there is different title text set for .highlighted and .disabled states, then we should re-style that as well.

## Scope ##

Added production code

## Screenshot ##

![Simulator Screen Recording - iPhone 14 Pro - 2022-10-27 at 15 20 33](https://user-images.githubusercontent.com/112933774/198253157-c8b2490c-3be1-4810-9b11-d70bcef120c8.gif)
