### PR TITLE
[SwiftUI] Add TextStyleLabel #55

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ label.typography = .headline
 
 What you should _not_ do, however, is set the `font` property directly. Just set the typography and the class will take care of the font.
 
+### Using Typography in SwiftUI
+To make the Typography elements work within the SwiftUI framework, we used `UIViewRepresentable`, a wrapper for a UIKit that integrates the view into your SwiftUI view hierarchy.
+
+*Rendering Single Line Label:* `TextStyleLabel` is the first wrapper component we created, it renders a single line `TypographyLabel`, and as such, has the property `numberOfLines = 1`. Setting this property to any other value is undefined behavior.
+```
+// using `TextStyleLabel` in SwiftUI
+TextStyleLabel("Another sample headline", typography: .systemLabel)
+```
+
+To add specific TypographyLabel configurations, use the `configuration` closure:
+ ```
+// using custom typography, the configuration closure and a View background modifier
+TextStyleLabel(
+    "This is a long text string that will not fit",
+    typography: .ParagraphUber.small.fontSize(28).lineHeight(45),
+    configuration: { label in
+        label.lineBreakMode = .byTruncatingMiddle
+    })
+.background(Color.yellow.opacity(0.5))
+```
+
 ## Registering Custom Fonts
 
 Any custom fonts need to be included as assets in your application and registered with the system. If you're building a simple app then you can just add them to your project and list them in your app's Info.plist file as you normally would. If, however, you want to build them into a separate Swift package, then that's fine too, and Y—MatterType has an extension on `UIFont` that makes it easier to register (and unregister) your font files. It throws an error if the font cannot be registered (and also if it has already been registered), so you'll know when you have a problem. Note that you will need to specify `subpath` if you use `.copy` for the resources in your Swift package file (and probably won't need to specify it if you use `.process`).

--- a/Sources/YMatterType/Elements/Representables/TypographyLabelRepresentable.swift
+++ b/Sources/YMatterType/Elements/Representables/TypographyLabelRepresentable.swift
@@ -1,0 +1,56 @@
+//
+//  TypographyLabelRepresentable.swift
+//  YMatterType
+//
+//  Created by Virginia Pujols on 1/27/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import SwiftUI
+
+/// A wrapper for a UIKit TypographyLabel view that allows to integrate that view into a SwiftUI view hierarchy.
+struct TypographyLabelRepresentable: UIViewRepresentable {
+    /// The type of view to present.
+    typealias UIViewType = TypographyLabel
+
+    /// The text that the label displays.
+    var text: String
+    
+    /// Typography to be used for this label's text
+    var typography: Typography
+    
+    /// A closure that gets called on the init and refresh of the View
+    var configureTextStyleLabel: ((TypographyLabel) -> Void)?
+
+    /// Creates the view object and configures its initial state.
+    ///
+    /// - Parameter context: A context structure containing information about
+    ///   the current state of the system.
+    ///
+    /// - Returns: `TypographyLabel` view configured with the provided information.
+    func makeUIView(context: Context) -> TypographyLabel {
+        let label = TypographyLabel(typography: typography)
+        label.text = text
+        
+        label.numberOfLines = 1
+
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+
+        configureTextStyleLabel?(label)
+        return label
+    }
+    
+    /// Updates the state of the specified view with new information from
+    /// SwiftUI.
+    ///
+    /// - Parameters:
+    ///   - uiView: `TypographyLabel` view.
+    ///   - context: A context structure containing information about the current
+    ///     state of the system.
+    func updateUIView(_ uiView: TypographyLabel, context: Context) {
+        uiView.typography = typography
+        uiView.text = text
+        configureTextStyleLabel?(uiView)
+    }
+}

--- a/Sources/YMatterType/Elements/TextStyleLabel.swift
+++ b/Sources/YMatterType/Elements/TextStyleLabel.swift
@@ -11,14 +11,14 @@ import SwiftUI
 /// A singe line text label that supports `Typography` for SwiftUI.
 public struct TextStyleLabel: View {
     /// The text that the label displays.
-    let text: String
+    var text: String
     
     /// Typography to be used for this label's text
-    let typography: Typography
+    var typography: Typography
     
     /// A closure that gets called on the init and refresh of the View
     /// This closure allows you to provide additional configuration to the `TypographyLabel`
-    let configureTextStyleLabel: ((TypographyLabel) -> Void)?
+    var configureTextStyleLabel: ((TypographyLabel) -> Void)?
 
     /// The content and behavior of the view.
     public var body: some View {
@@ -43,54 +43,5 @@ public struct TextStyleLabel: View {
         self.typography = typography
         self.text = text
         self.configureTextStyleLabel = configuration
-    }
-}
-
-extension TextStyleLabel {
-    /// A wrapper for a UIKit TypographyLabel view that allows to integrate that view into a SwiftUI view hierarchy.
-    struct TypographyLabelRepresentable: UIViewRepresentable {
-        /// The type of view to present.
-        typealias UIViewType = TypographyLabel
-
-        /// The text that the label displays.
-        let text: String
-        
-        /// Typography to be used for this label's text
-        let typography: Typography
-        
-        /// A closure that gets called on the init and refresh of the View
-        let configureTextStyleLabel: ((TypographyLabel) -> Void)?
-
-        /// Creates the view object and configures its initial state.
-        ///
-        /// - Parameter context: A context structure containing information about
-        ///   the current state of the system.
-        ///
-        /// - Returns: `TypographyLabel` view configured with the provided information.
-        func makeUIView(context: Context) -> TypographyLabel {
-            let label = TypographyLabel(typography: typography)
-            label.text = text
-            
-            label.numberOfLines = 1
-
-            label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-            label.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
-
-            configureTextStyleLabel?(label)
-            return label
-        }
-        
-        /// Updates the state of the specified view with new information from
-        /// SwiftUI.
-        ///
-        /// - Parameters:
-        ///   - uiView: `TypographyLabel` view.
-        ///   - context: A context structure containing information about the current
-        ///     state of the system.
-        func updateUIView(_ uiView: TypographyLabel, context: Context) {
-            uiView.typography = typography
-            uiView.text = text
-            configureTextStyleLabel?(uiView)
-        }
     }
 }

--- a/Sources/YMatterType/Elements/TextStyleLabel.swift
+++ b/Sources/YMatterType/Elements/TextStyleLabel.swift
@@ -8,44 +8,66 @@
 
 import SwiftUI
 
+/// A singe line text label that supports `Typography` for SwiftUI.
 public struct TextStyleLabel: View {
-    private let text: String
-    private let typography: Typography
-    private let configureTypographyText: ((TypographyLabel) -> Void)?
+    /// The text that the label displays.
+    let text: String
+    
+    /// Typography to be used for this label's text
+    let typography: Typography
+    
+    /// A closure that gets called on the init and refresh of the View
+    /// This closure allows you to provide additional configuration to the `TypographyLabel`
+    let configureTextStyleLabel: ((TypographyLabel) -> Void)?
 
-    public init(_ text: String,
-                typography: Typography,
-                configuration: ((TypographyLabel) -> Void)? = nil) {
-        self.typography = typography
-        self.text = text
-        self.configureTypographyText = configuration
+    /// The content and behavior of the view.
+    public var body: some View {
+        TypographyLabelRepresentable(
+            text: text,
+            typography: typography,
+            configureTextStyleLabel: configureTextStyleLabel
+        )
+        .fixedSize(horizontal: false, vertical: true)
     }
 
-    public var body: some View {
-        TypographyLabelRepresentable(text,
-                                     typography: typography,
-                                     configuration: configureTypographyText)
-            .fixedSize(horizontal: false, vertical: true)
+    /// Initializes a `TextStyleLabel` instance with the specified parameters
+    /// - Parameters:
+    ///   - text: The text that the label displays
+    ///   - typography: Typography to be used for this label's text
+    ///   - configuration: A closure that gets called on the init and refresh of the View
+    public init(
+        _ text: String,
+        typography: Typography,
+        configuration: ((TypographyLabel) -> Void)? = nil
+    ) {
+        self.typography = typography
+        self.text = text
+        self.configureTextStyleLabel = configuration
     }
 }
 
-public extension TextStyleLabel {
+extension TextStyleLabel {
+    /// A wrapper for a UIKit TypographyLabel view that allows to integrate that view into a SwiftUI view hierarchy.
     struct TypographyLabelRepresentable: UIViewRepresentable {
-        public typealias UIViewType = TypographyLabel
+        /// The type of view to present.
+        typealias UIViewType = TypographyLabel
 
-        private let typography: Typography
-        private let text: String
-        private let configureText: ((TypographyLabel) -> Void)?
-
-        public init(_ text: String,
-                    typography: Typography,
-                    configuration: ((TypographyLabel) -> Void)? = nil) {
-            self.typography = typography
-            self.text = text
-            self.configureText = configuration
-        }
+        /// The text that the label displays.
+        let text: String
         
-        public func makeUIView(context: Context) -> TypographyLabel {
+        /// Typography to be used for this label's text
+        let typography: Typography
+        
+        /// A closure that gets called on the init and refresh of the View
+        let configureTextStyleLabel: ((TypographyLabel) -> Void)?
+
+        /// Creates the view object and configures its initial state.
+        ///
+        /// - Parameter context: A context structure containing information about
+        ///   the current state of the system.
+        ///
+        /// - Returns: `TypographyLabel` view configured with the provided information.
+        func makeUIView(context: Context) -> TypographyLabel {
             let label = TypographyLabel(typography: typography)
             label.text = text
             
@@ -54,14 +76,21 @@ public extension TextStyleLabel {
             label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
             label.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
 
-            configureText?(label)
+            configureTextStyleLabel?(label)
             return label
         }
         
-        public func updateUIView(_ uiView: TypographyLabel, context: Context) {
+        /// Updates the state of the specified view with new information from
+        /// SwiftUI.
+        ///
+        /// - Parameters:
+        ///   - uiView: `TypographyLabel` view.
+        ///   - context: A context structure containing information about the current
+        ///     state of the system.
+        func updateUIView(_ uiView: TypographyLabel, context: Context) {
             uiView.typography = typography
             uiView.text = text
-            configureText?(uiView)
+            configureTextStyleLabel?(uiView)
         }
     }
 }

--- a/Sources/YMatterType/Elements/TextStyleLabel.swift
+++ b/Sources/YMatterType/Elements/TextStyleLabel.swift
@@ -1,0 +1,67 @@
+//
+//  TextStyleLabel.swift
+//  YMatterType
+//
+//  Created by Virginia Pujols on 1/11/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import SwiftUI
+
+public struct TextStyleLabel: View {
+    private let text: String
+    private let typography: Typography
+    private let configureTypographyText: ((TypographyLabel) -> Void)?
+
+    public init(_ text: String,
+                typography: Typography,
+                configuration: ((TypographyLabel) -> Void)? = nil) {
+        self.typography = typography
+        self.text = text
+        self.configureTypographyText = configuration
+    }
+
+    public var body: some View {
+        TypographyLabelRepresentable(text,
+                                     typography: typography,
+                                     configuration: configureTypographyText)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+public extension TextStyleLabel {
+    struct TypographyLabelRepresentable: UIViewRepresentable {
+        public typealias UIViewType = TypographyLabel
+
+        private let typography: Typography
+        private let text: String
+        private let configureText: ((TypographyLabel) -> Void)?
+
+        public init(_ text: String,
+                    typography: Typography,
+                    configuration: ((TypographyLabel) -> Void)? = nil) {
+            self.typography = typography
+            self.text = text
+            self.configureText = configuration
+        }
+        
+        public func makeUIView(context: Context) -> TypographyLabel {
+            let label = TypographyLabel(typography: typography)
+            label.text = text
+            
+            label.numberOfLines = 1
+
+            label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            label.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+
+            configureText?(label)
+            return label
+        }
+        
+        public func updateUIView(_ uiView: TypographyLabel, context: Context) {
+            uiView.typography = typography
+            uiView.text = text
+            configureText?(uiView)
+        }
+    }
+}

--- a/Tests/YMatterTypeTests/Elements/TextStyleLabelTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TextStyleLabelTests.swift
@@ -19,46 +19,14 @@ final class TextStyleLabelTests: XCTestCase {
         let fontSize = Constants.fontSize
         let expectedTypography = Typography.systemLabel.fontSize(fontSize)
         let expectedText = Constants.helloWorldText
-        
-        let label = TypographyLabel(typography: expectedTypography)
-        let labelConfig = { (label: TypographyLabel) in
-            label.lineBreakMode = .byTruncatingMiddle
-        }
-        labelConfig(label)
 
         // Given a TextStyleLabel with a single line of text
-        let sut = TextStyleLabel(expectedText, typography: expectedTypography)
-        
-        // we expect a value
-        XCTAssertNotNil(sut)
-        
-        // we expect the text to match the expected
-        XCTAssertEqual(sut.text, expectedText)
-        
-        // we expect the font to match the expected
-        XCTAssertEqual(sut.typography.fontSize, fontSize)
-        
-        // we expect the configuration closusure to update the label
-        XCTAssertEqual(label.lineBreakMode, .byTruncatingMiddle)
-    }
-
-    func testTypographyLabelRepresentable() throws {
-        let fontSize = Constants.fontSize
-
-        let expectedTypography = Typography.systemLabel.fontSize(fontSize)
-        let expectedText = Constants.helloWorldText
-
-        let label = TypographyLabel(typography: expectedTypography)
-        let labelConfig = { (label: TypographyLabel) in
-            label.textColor = .darkText
-        }
-        labelConfig(label)
-
-        // Given a TypographyLabelRepresentable with a single line of text
-        let sut = TextStyleLabel.TypographyLabelRepresentable(
-            text: expectedText,
+        let sut = TextStyleLabel(
+            expectedText,
             typography: expectedTypography,
-            configureTextStyleLabel: nil
+            configuration: { (label: TypographyLabel) in
+                label.lineBreakMode = .byTruncatingMiddle
+            }
         )
 
         // we expect a value
@@ -71,6 +39,41 @@ final class TextStyleLabelTests: XCTestCase {
         XCTAssertEqual(sut.typography.fontSize, fontSize)
         
         // we expect the configuration closusure to update the label
-        XCTAssertEqual(label.textColor, .darkText)
+        let labelToUpdate = TypographyLabel(typography: expectedTypography)
+        XCTAssertNotEqual(labelToUpdate.lineBreakMode, .byTruncatingMiddle)
+
+        sut.configureTextStyleLabel?(labelToUpdate)
+        XCTAssertEqual(labelToUpdate.lineBreakMode, .byTruncatingMiddle)
+    }
+
+    func testTypographyLabelRepresentable() throws {
+        let fontSize = Constants.fontSize
+
+        let expectedTypography = Typography.systemLabel.fontSize(fontSize)
+        let expectedText = Constants.helloWorldText
+
+        // Given a TypographyLabelRepresentable with a single line of text
+        let sut = TypographyLabelRepresentable(
+            text: expectedText,
+            typography: expectedTypography,
+            configureTextStyleLabel: { (label: TypographyLabel) in
+                label.textColor = .yellow
+            }
+        )
+        // we expect a value
+        XCTAssertNotNil(sut)
+        
+        // we expect the text to match the expected
+        XCTAssertEqual(sut.text, expectedText)
+        
+        // we expect the font to match the expected
+        XCTAssertEqual(sut.typography.fontSize, fontSize)
+        
+        // we expect the configuration closusure to update the label
+        let labelToUpdate = TypographyLabel(typography: expectedTypography)
+        XCTAssertNotEqual(labelToUpdate.textColor, .yellow)
+        
+        sut.configureTextStyleLabel?(labelToUpdate)
+        XCTAssertEqual(labelToUpdate.textColor, .yellow)
     }
 }

--- a/Tests/YMatterTypeTests/Elements/TextStyleLabelTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TextStyleLabelTests.swift
@@ -1,0 +1,76 @@
+//
+//  TextStyleLabelTests.swift
+//  YMatterTypeTests
+//
+//  Created by Virginia Pujols on 1/26/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YMatterType
+
+final class TextStyleLabelTests: XCTestCase {
+    enum Constants {
+        static let helloWorldText = "Hello, World"
+        static let fontSize = CGFloat.random(in: 10...60)
+    }
+    
+    func testTextStyleLabelSingleLine() throws {
+        let fontSize = Constants.fontSize
+        let expectedTypography = Typography.systemLabel.fontSize(fontSize)
+        let expectedText = Constants.helloWorldText
+        
+        let label = TypographyLabel(typography: expectedTypography)
+        let labelConfig = { (label: TypographyLabel) in
+            label.lineBreakMode = .byTruncatingMiddle
+        }
+        labelConfig(label)
+
+        // Given a TextStyleLabel with a single line of text
+        let sut = TextStyleLabel(expectedText, typography: expectedTypography)
+        
+        // we expect a value
+        XCTAssertNotNil(sut)
+        
+        // we expect the text to match the expected
+        XCTAssertEqual(sut.text, expectedText)
+        
+        // we expect the font to match the expected
+        XCTAssertEqual(sut.typography.fontSize, fontSize)
+        
+        // we expect the configuration closusure to update the label
+        XCTAssertEqual(label.lineBreakMode, .byTruncatingMiddle)
+    }
+
+    func testTypographyLabelRepresentable() throws {
+        let fontSize = Constants.fontSize
+
+        let expectedTypography = Typography.systemLabel.fontSize(fontSize)
+        let expectedText = Constants.helloWorldText
+
+        let label = TypographyLabel(typography: expectedTypography)
+        let labelConfig = { (label: TypographyLabel) in
+            label.textColor = .darkText
+        }
+        labelConfig(label)
+
+        // Given a TypographyLabelRepresentable with a single line of text
+        let sut = TextStyleLabel.TypographyLabelRepresentable(
+            text: expectedText,
+            typography: expectedTypography,
+            configureTextStyleLabel: nil
+        )
+
+        // we expect a value
+        XCTAssertNotNil(sut)
+        
+        // we expect the text to match the expected
+        XCTAssertEqual(sut.text, expectedText)
+        
+        // we expect the font to match the expected
+        XCTAssertEqual(sut.typography.fontSize, fontSize)
+        
+        // we expect the configuration closusure to update the label
+        XCTAssertEqual(label.textColor, .darkText)
+    }
+}


### PR DESCRIPTION
## Introduction ##

Create TextStyleLabel component.

## Purpose ##

Allow TypographyLabel with a single line to be used within SwiftUI. Issue #55 

## Scope ##

Added new file `TextStyleLabel.swift` and updated the README.md

## Discussion ##

**Unit Tests:** Apple doesn’t provide any testing framework for SwiftUI yet or a way to have UI test within a Swift Package. Since the solution to include unit tests for this component is not straightforward, I'll create a separate PR for it.

## 🎬 Video ##

Apologies for the bad quality (10MB limit issue):

https://user-images.githubusercontent.com/122470090/214679564-69af0895-218e-40a1-ae92-ee17fb35ee48.mov



