### PR TITLE
[SwiftUI] Add TextStyleLabel unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ label.typography = .headline
 
 What you should _not_ do, however, is set the `font` property directly. Just set the typography and the class will take care of the font.
 
+### Using Typography in SwiftUI
+To make the Typography elements work within the SwiftUI framework, we used `UIViewRepresentable`, a wrapper for a UIKit that integrates the view into your SwiftUI view hierarchy.
+
+*Rendering Single Line Label:* `TextStyleLabel` is the first wrapper component we created, it renders a single line `TypographyLabel`, and as such, has the property `numberOfLines = 1`. Setting this property to any other value is undefined behavior.
+```
+// using `TextStyleLabel` in SwiftUI
+TextStyleLabel("Another sample headline", typography: .systemLabel)
+```
+
+To add specific TypographyLabel configurations, use the `configuration` closure:
+ ```
+// using custom typography, the configuration closure and a View background modifier
+TextStyleLabel(
+    "This is a long text string that will not fit",
+    typography: .ParagraphUber.small.fontSize(28).lineHeight(45),
+    configuration: { label in
+        label.lineBreakMode = .byTruncatingMiddle
+    })
+.background(Color.yellow.opacity(0.5))
+```
+
 ## Registering Custom Fonts
 
 Any custom fonts need to be included as assets in your application and registered with the system. If you're building a simple app then you can just add them to your project and list them in your app's Info.plist file as you normally would. If, however, you want to build them into a separate Swift package, then that's fine too, and Y—MatterType has an extension on `UIFont` that makes it easier to register (and unregister) your font files. It throws an error if the font cannot be registered (and also if it has already been registered), so you'll know when you have a problem. Note that you will need to specify `subpath` if you use `.copy` for the resources in your Swift package file (and probably won't need to specify it if you use `.process`).

--- a/Sources/YMatterType/Elements/TextStyleLabel.swift
+++ b/Sources/YMatterType/Elements/TextStyleLabel.swift
@@ -1,0 +1,67 @@
+//
+//  TextStyleLabel.swift
+//  YMatterType
+//
+//  Created by Virginia Pujols on 1/11/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import SwiftUI
+
+public struct TextStyleLabel: View {
+    private let text: String
+    private let typography: Typography
+    private let configureTypographyText: ((TypographyLabel) -> Void)?
+
+    public init(_ text: String,
+                typography: Typography,
+                configuration: ((TypographyLabel) -> Void)? = nil) {
+        self.typography = typography
+        self.text = text
+        self.configureTypographyText = configuration
+    }
+
+    public var body: some View {
+        TypographyLabelRepresentable(text,
+                                     typography: typography,
+                                     configuration: configureTypographyText)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+public extension TextStyleLabel {
+    struct TypographyLabelRepresentable: UIViewRepresentable {
+        public typealias UIViewType = TypographyLabel
+
+        private let typography: Typography
+        private let text: String
+        private let configureText: ((TypographyLabel) -> Void)?
+
+        public init(_ text: String,
+                    typography: Typography,
+                    configuration: ((TypographyLabel) -> Void)? = nil) {
+            self.typography = typography
+            self.text = text
+            self.configureText = configuration
+        }
+        
+        public func makeUIView(context: Context) -> TypographyLabel {
+            let label = TypographyLabel(typography: typography)
+            label.text = text
+            
+            label.numberOfLines = 1
+
+            label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            label.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+
+            configureText?(label)
+            return label
+        }
+        
+        public func updateUIView(_ uiView: TypographyLabel, context: Context) {
+            uiView.typography = typography
+            uiView.text = text
+            configureText?(uiView)
+        }
+    }
+}

--- a/Xcode/Playground/Playground.xcodeproj/project.pbxproj
+++ b/Xcode/Playground/Playground.xcodeproj/project.pbxproj
@@ -1,0 +1,535 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		F10B46F82980B54700E2A68D /* PlaygroundApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B46F72980B54700E2A68D /* PlaygroundApp.swift */; };
+		F10B46FA2980B54700E2A68D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B46F92980B54700E2A68D /* ContentView.swift */; };
+		F10B46FC2980B54900E2A68D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F10B46FB2980B54900E2A68D /* Assets.xcassets */; };
+		F10B46FF2980B54900E2A68D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F10B46FE2980B54900E2A68D /* Preview Assets.xcassets */; };
+		F10B47092980B54900E2A68D /* TextStyleLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B47082980B54900E2A68D /* TextStyleLabelTests.swift */; };
+		F10B47292980B66100E2A68D /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = F10B47282980B66100E2A68D /* ViewInspector */; };
+		F10B47302980B8EA00E2A68D /* TextStyleLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B472F2980B8EA00E2A68D /* TextStyleLabelView.swift */; };
+		F18F052F2981E3D200BCC83E /* YMatterType in Frameworks */ = {isa = PBXBuildFile; productRef = F18F052E2981E3D200BCC83E /* YMatterType */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		F10B47052980B54900E2A68D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F10B46EC2980B54700E2A68D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F10B46F32980B54700E2A68D;
+			remoteInfo = Playground;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		F10B46F42980B54700E2A68D /* Playground.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Playground.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F10B46F72980B54700E2A68D /* PlaygroundApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundApp.swift; sourceTree = "<group>"; };
+		F10B46F92980B54700E2A68D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		F10B46FB2980B54900E2A68D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		F10B46FE2980B54900E2A68D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		F10B47042980B54900E2A68D /* PlaygroundTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlaygroundTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F10B47082980B54900E2A68D /* TextStyleLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleLabelTests.swift; sourceTree = "<group>"; };
+		F10B472F2980B8EA00E2A68D /* TextStyleLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleLabelView.swift; sourceTree = "<group>"; };
+		F18F052D2981E34A00BCC83E /* YMatterType */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = YMatterType; path = ../..; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F10B46F12980B54700E2A68D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F18F052F2981E3D200BCC83E /* YMatterType in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F10B47012980B54900E2A68D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F10B47292980B66100E2A68D /* ViewInspector in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		F10B46EB2980B54700E2A68D = {
+			isa = PBXGroup;
+			children = (
+				F18F052C2981E34A00BCC83E /* Packages */,
+				F10B46F62980B54700E2A68D /* Playground */,
+				F10B47072980B54900E2A68D /* PlaygroundTests */,
+				F10B46F52980B54700E2A68D /* Products */,
+				F10B472C2980B6C900E2A68D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		F10B46F52980B54700E2A68D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F10B46F42980B54700E2A68D /* Playground.app */,
+				F10B47042980B54900E2A68D /* PlaygroundTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F10B46F62980B54700E2A68D /* Playground */ = {
+			isa = PBXGroup;
+			children = (
+				F10B46F72980B54700E2A68D /* PlaygroundApp.swift */,
+				F10B46F92980B54700E2A68D /* ContentView.swift */,
+				F10B472F2980B8EA00E2A68D /* TextStyleLabelView.swift */,
+				F10B46FB2980B54900E2A68D /* Assets.xcassets */,
+				F10B46FD2980B54900E2A68D /* Preview Content */,
+			);
+			path = Playground;
+			sourceTree = "<group>";
+		};
+		F10B46FD2980B54900E2A68D /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				F10B46FE2980B54900E2A68D /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		F10B47072980B54900E2A68D /* PlaygroundTests */ = {
+			isa = PBXGroup;
+			children = (
+				F10B47082980B54900E2A68D /* TextStyleLabelTests.swift */,
+			);
+			path = PlaygroundTests;
+			sourceTree = "<group>";
+		};
+		F10B472C2980B6C900E2A68D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F18F052C2981E34A00BCC83E /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				F18F052D2981E34A00BCC83E /* YMatterType */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		F10B46F32980B54700E2A68D /* Playground */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F10B47182980B54900E2A68D /* Build configuration list for PBXNativeTarget "Playground" */;
+			buildPhases = (
+				F10B46F02980B54700E2A68D /* Sources */,
+				F10B46F12980B54700E2A68D /* Frameworks */,
+				F10B46F22980B54700E2A68D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Playground;
+			packageProductDependencies = (
+				F18F052E2981E3D200BCC83E /* YMatterType */,
+			);
+			productName = Playground;
+			productReference = F10B46F42980B54700E2A68D /* Playground.app */;
+			productType = "com.apple.product-type.application";
+		};
+		F10B47032980B54900E2A68D /* PlaygroundTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F10B471B2980B54900E2A68D /* Build configuration list for PBXNativeTarget "PlaygroundTests" */;
+			buildPhases = (
+				F10B47002980B54900E2A68D /* Sources */,
+				F10B47012980B54900E2A68D /* Frameworks */,
+				F10B47022980B54900E2A68D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F10B47062980B54900E2A68D /* PBXTargetDependency */,
+			);
+			name = PlaygroundTests;
+			packageProductDependencies = (
+				F10B47282980B66100E2A68D /* ViewInspector */,
+			);
+			productName = PlaygroundTests;
+			productReference = F10B47042980B54900E2A68D /* PlaygroundTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F10B46EC2980B54700E2A68D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1410;
+				LastUpgradeCheck = 1410;
+				TargetAttributes = {
+					F10B46F32980B54700E2A68D = {
+						CreatedOnToolsVersion = 14.1;
+					};
+					F10B47032980B54900E2A68D = {
+						CreatedOnToolsVersion = 14.1;
+						TestTargetID = F10B46F32980B54700E2A68D;
+					};
+				};
+			};
+			buildConfigurationList = F10B46EF2980B54700E2A68D /* Build configuration list for PBXProject "Playground" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = F10B46EB2980B54700E2A68D;
+			packageReferences = (
+				F10B47272980B66100E2A68D /* XCRemoteSwiftPackageReference "ViewInspector" */,
+			);
+			productRefGroup = F10B46F52980B54700E2A68D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F10B46F32980B54700E2A68D /* Playground */,
+				F10B47032980B54900E2A68D /* PlaygroundTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F10B46F22980B54700E2A68D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F10B46FF2980B54900E2A68D /* Preview Assets.xcassets in Resources */,
+				F10B46FC2980B54900E2A68D /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F10B47022980B54900E2A68D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F10B46F02980B54700E2A68D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F10B46FA2980B54700E2A68D /* ContentView.swift in Sources */,
+				F10B47302980B8EA00E2A68D /* TextStyleLabelView.swift in Sources */,
+				F10B46F82980B54700E2A68D /* PlaygroundApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F10B47002980B54900E2A68D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F10B47092980B54900E2A68D /* TextStyleLabelTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		F10B47062980B54900E2A68D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F10B46F32980B54700E2A68D /* Playground */;
+			targetProxy = F10B47052980B54900E2A68D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		F10B47162980B54900E2A68D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		F10B47172980B54900E2A68D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		F10B47192980B54900E2A68D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Playground/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ymedialabs.ymatter.Playground;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		F10B471A2980B54900E2A68D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Playground/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ymedialabs.ymatter.Playground;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		F10B471C2980B54900E2A68D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ymedialabs.ymatter.PlaygroundTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Playground.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Playground";
+			};
+			name = Debug;
+		};
+		F10B471D2980B54900E2A68D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ymedialabs.ymatter.PlaygroundTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Playground.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Playground";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F10B46EF2980B54700E2A68D /* Build configuration list for PBXProject "Playground" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F10B47162980B54900E2A68D /* Debug */,
+				F10B47172980B54900E2A68D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F10B47182980B54900E2A68D /* Build configuration list for PBXNativeTarget "Playground" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F10B47192980B54900E2A68D /* Debug */,
+				F10B471A2980B54900E2A68D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F10B471B2980B54900E2A68D /* Build configuration list for PBXNativeTarget "PlaygroundTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F10B471C2980B54900E2A68D /* Debug */,
+				F10B471D2980B54900E2A68D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		F10B47272980B66100E2A68D /* XCRemoteSwiftPackageReference "ViewInspector" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/nalexn/ViewInspector";
+			requirement = {
+				kind = exactVersion;
+				version = 0.9.5;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		F10B47282980B66100E2A68D /* ViewInspector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F10B47272980B66100E2A68D /* XCRemoteSwiftPackageReference "ViewInspector" */;
+			productName = ViewInspector;
+		};
+		F18F052E2981E3D200BCC83E /* YMatterType */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = YMatterType;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = F10B46EC2980B54700E2A68D /* Project object */;
+}

--- a/Xcode/Playground/Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Xcode/Playground/Playground.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "viewinspector",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nalexn/ViewInspector",
+      "state" : {
+        "revision" : "4effbd9143ab797eb60d2f32d4265c844c980946",
+        "version" : "0.9.5"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Xcode/Playground/Playground/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Xcode/Playground/Playground/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Xcode/Playground/Playground/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Xcode/Playground/Playground/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Xcode/Playground/Playground/Assets.xcassets/Contents.json
+++ b/Xcode/Playground/Playground/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Xcode/Playground/Playground/ContentView.swift
+++ b/Xcode/Playground/Playground/ContentView.swift
@@ -1,0 +1,26 @@
+//
+//  ContentView.swift
+//  Playground
+//
+//  Created by Virginia Pujols on 1/24/23.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Xcode/Playground/Playground/PlaygroundApp.swift
+++ b/Xcode/Playground/Playground/PlaygroundApp.swift
@@ -1,0 +1,17 @@
+//
+//  PlaygroundApp.swift
+//  Playground
+//
+//  Created by Virginia Pujols on 1/24/23.
+//
+
+import SwiftUI
+
+@main
+struct PlaygroundApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Xcode/Playground/Playground/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Xcode/Playground/Playground/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Xcode/Playground/Playground/TextStyleLabelView.swift
+++ b/Xcode/Playground/Playground/TextStyleLabelView.swift
@@ -1,0 +1,33 @@
+//
+//  TextStyleLabelView.swift
+//  Playground
+//
+//  Created by Virginia Pujols on 1/24/23.
+//
+
+import SwiftUI
+import YMatterType
+
+struct TextStyleLabelView: View {
+    
+    var typograpy: Typography = .systemLabel.fontSize(28).lineHeight(43)
+    var lineBreakMode: NSLineBreakMode = .byTruncatingMiddle
+    var displayText = "This is a long text that will be truncated"
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            TextStyleLabel(displayText,
+                           typography: typograpy, configuration: { label in
+                label.lineBreakMode = lineBreakMode
+            })
+            .background(Color.yellow.opacity(0.5))
+        }
+        .padding()
+    }
+}
+
+struct TextStyleLabelView_Previews: PreviewProvider {
+    static var previews: some View {
+        TextStyleLabelView()
+    }
+}

--- a/Xcode/Playground/PlaygroundTests/TextStyleLabelTests.swift
+++ b/Xcode/Playground/PlaygroundTests/TextStyleLabelTests.swift
@@ -1,0 +1,52 @@
+//
+//  TextStyleLabelTests.swift
+//  TextStyleLabelTests
+//
+//  Created by Virginia Pujols on 1/24/23.
+//
+
+import XCTest
+import SwiftUI
+import ViewInspector
+import YMatterType
+@testable import Playground
+
+final class TextStyleLabelTests: XCTestCase {
+    private struct TextConstants {
+        static let helloWorld = "Hello, world!"
+    }
+
+    func testInspectorBaseline() throws {
+        let expected = TextConstants.helloWorld
+        
+        let sut = Text(expected)
+        
+        let value = try sut.inspect().text().string()
+        XCTAssertEqual(value, expected)
+    }
+    
+    func testContentViewTextValue() throws {
+        let view = ContentView()
+        
+        let expected = TextConstants.helloWorld
+        let sut = try view.inspect().find(text: expected)
+        
+        let value = try sut.string()
+        XCTAssertEqual(value, expected)
+    }
+    
+    func testTextStyleLabelSingleLine() throws {
+        let view = TextStyleLabelView()
+        ViewHosting.host(view: view)
+
+        let textContainer = try view.inspect().find(TextStyleLabel.self)
+        let sut = try textContainer.find(TextStyleLabel.TypographyLabelRepresentable.self).actualView().uiView()
+
+        XCTAssertNotNil(sut)
+        XCTAssertEqual(sut.font.pointSize, view.typograpy.fontSize)
+        XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight)
+        XCTAssertEqual(sut.lineBreakMode, .byTruncatingMiddle)
+        XCTAssertEqual(sut.numberOfLines, 1)
+        XCTAssertEqual(sut.text, view.displayText)
+    }
+}


### PR DESCRIPTION
## Introduction ##

Creating SwiftUI tests within the Swift Package manager, as of now is very limited. Views need the context of a simulator in order to be tested.  Issue #55 

## Purpose ##

Create a “Playground” iOS project that uses and tests our TextStyleLabel component.

## Scope ##

- Create an Xcode folder at the root of our package and add an iOS App project inside
- Use the project as a playground for the YMatterType package implementing TextStyleLabel and adding tests.
- Use the ViewInspector package to help inspect the SwiftUI view hierarchy at runtime.

