### PR TITLE
[58] Fix swiftlint config warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,7 +4,6 @@ disabled_rules: # rule identifiers turned on by default to exclude from running
   - multiple_closures_with_trailing_closure
 
 opt_in_rules: # some rules are turned off by default, so you need to opt-in
-  - anyobject_protocol
   - contains_over_first_not_nil
   - empty_count
   - first_where
@@ -20,7 +19,6 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - operator_whitespace
   - prohibited_interface_builder
   - unneeded_parentheses_in_closure_argument
-  - unused_import
   - vertical_whitespace_closing_braces
   - vertical_whitespace_opening_braces
 


### PR DESCRIPTION
## Introduction ##

The console output from SwiftLint is complaining about two of our rules, which are either not applied or are obsolete. So we're removing them.

## Purpose ##

Resolve SwiftLint warnings about unused/obsolete rules (Fix #58)

## Scope ##

Update `.swiftlint.yml` config file

## Discussion ##

Need to apply these changes to all of our open source repos

## 📈 Coverage ##

Both unit test and documentation coverage are unchanged.