### PR TITLE
[Issue-60] Add HelveticaNeue font family

### DIFF
--- a/Sources/YMatterType/Typography/FontFamily/DefaultFontFamilyFactory.swift
+++ b/Sources/YMatterType/Typography/FontFamily/DefaultFontFamilyFactory.swift
@@ -15,12 +15,16 @@ public struct DefaultFontFamilyFactory {
 }
 
 extension DefaultFontFamilyFactory: FontFamilyFactory {
-    /// Given a family name and style instantiates and returns a `DefaultFontFamily`
+    /// Given a family name and style instantiates and returns an appropriate `FontFamily` to use.
     /// - Parameters:
     ///   - familyName: font family name
     ///   - style: font style
     /// - Returns: a font family matching the family name and style
     public func getFontFamily(familyName: String, style: Typography.FontStyle) -> FontFamily {
-        DefaultFontFamily(familyName: familyName, style: style)
+        if familyName == HelveticaNeueFontFamily.familyName {
+            return HelveticaNeueFontFamily(style: style)
+        }
+
+        return DefaultFontFamily(familyName: familyName, style: style)
     }
 }

--- a/Sources/YMatterType/Typography/FontFamily/FontFamily.swift
+++ b/Sources/YMatterType/Typography/FontFamily/FontFamily.swift
@@ -108,7 +108,12 @@ extension FontFamily {
         let useBoldFont = isBoldTextEnabled(compatibleWith: traitCollection)
         let actualWeight = useBoldFont ? accessibilityBoldWeight(for: weight) : weight
         let weightName = weightName(for: actualWeight)
-        return "\(familyName)-\(weightName)\(fontNameSuffix)"
+        let suffix = fontNameSuffix
+        if weightName.isEmpty && suffix.isEmpty {
+            // don't use "-" if nothing will follow it
+            return familyName
+        }
+        return "\(familyName)-\(weightName)\(suffix)"
     }
 
     /// Returns default name for each weight

--- a/Sources/YMatterType/Typography/FontFamily/HelveticaNeueFontFamily.swift
+++ b/Sources/YMatterType/Typography/FontFamily/HelveticaNeueFontFamily.swift
@@ -1,0 +1,65 @@
+//
+//  HelveticaNeueFontFamily.swift
+//  YMatterType
+//
+//  Created by Mark Pospesel on 3/2/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import UIKit
+
+public extension Typography {
+    /// HelveticaNeue font family
+    static let helveticaNeue = HelveticaNeueFontFamily(style: .regular)
+    /// HelveticaNeue Italic font family
+    static let helveticaNeueItalic = HelveticaNeueFontFamily(style: .italic)
+}
+
+/// Information about the Helvetica Neue family of fonts
+public struct HelveticaNeueFontFamily: FontFamily {
+    /// Font family root name
+    public let familyName: String = "HelveticaNeue"
+
+    /// Font style, e.g. regular or italic
+    public let style: Typography.FontStyle
+
+    /// Initialize a `HelveticaNeueFontFamily` object
+    /// - Parameter style: font style (default = `.regular`)
+    public init(style: Typography.FontStyle = .regular) {
+        self.style = style
+    }
+
+    /// HelveticaNeue supports 6 font weights (nothing heavier than bold)
+    public var supportedWeights: [Typography.FontWeight] {
+        [.ultralight, .thin, .light, .regular, .medium, .bold]
+    }
+
+    public func weightName(for weight: Typography.FontWeight) -> String {
+        // Default font name suffix by weight
+        switch weight {
+        case .ultralight:
+            return "UltraLight"
+        case .thin:
+            return "Thin"
+        case .light:
+            return "Light"
+        case .regular:
+            return "" // HelveticaNeue skips the weight name for regular
+        case .medium:
+            return "Medium"
+        case .bold:
+            return "Bold"
+        case .semibold, .heavy, .black:
+            return "" // HelveticaNeue does not support these weights
+        }
+    }
+
+    /// Optional suffix to use for the font name.
+    ///
+    /// Used by `FontFamily.fontName(for:compatibleWith:)`
+    /// e.g. "Italic" is a typical suffix for italic fonts.
+    /// default = ""
+    public var fontNameSuffix: String {
+        (style == .italic) ? DefaultFontFamily.italicSuffix : ""
+    }
+}

--- a/Sources/YMatterType/Typography/FontFamily/HelveticaNeueFontFamily.swift
+++ b/Sources/YMatterType/Typography/FontFamily/HelveticaNeueFontFamily.swift
@@ -18,7 +18,9 @@ public extension Typography {
 /// Information about the Helvetica Neue family of fonts
 public struct HelveticaNeueFontFamily: FontFamily {
     /// Font family root name
-    public let familyName: String = "HelveticaNeue"
+    public static let familyName = "HelveticaNeue"
+    /// Font family root name
+    public var familyName: String { HelveticaNeueFontFamily.familyName }
 
     /// Font style, e.g. regular or italic
     public let style: Typography.FontStyle

--- a/Tests/YMatterTypeTests/Typography/FontFamily/DefaultFontFamilyFactoryTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontFamily/DefaultFontFamilyFactoryTests.swift
@@ -17,6 +17,7 @@ final class DefaultFontFamilyFactoryTests: XCTestCase {
         // When
         let regular = sut.getFontFamily(familyName: "Foo", style: .regular)
         let italic = sut.getFontFamily(familyName: "Bar", style: .italic)
+        let helveticaNeue = sut.getFontFamily(familyName: "HelveticaNeue", style: .regular)
 
         // Then
         XCTAssertTrue(regular is DefaultFontFamily)
@@ -25,5 +26,7 @@ final class DefaultFontFamilyFactoryTests: XCTestCase {
         XCTAssertTrue(italic is DefaultFontFamily)
         XCTAssertEqual(italic.familyName, "Bar")
         XCTAssertEqual(italic.fontNameSuffix, "Italic")
+        XCTAssertEqual(helveticaNeue.familyName, "HelveticaNeue")
+        XCTAssertEqual(helveticaNeue.weightName(for: .regular), "")
     }
 }

--- a/Tests/YMatterTypeTests/Typography/FontFamily/FontFamilyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontFamily/FontFamilyTests.swift
@@ -112,6 +112,30 @@ final class FontFamilyTests: XCTestCase {
         // given traitCollection is nil, it should return the system setting
         XCTAssertEqual(sut.isBoldTextEnabled(compatibleWith: nil), UIAccessibility.isBoldTextEnabled)
     }
+
+    func test_fontNameWithoutWeightOrSuffix_isFamilyName() {
+        let sut = WeightlessFontFamily()
+        var name: String
+
+        // If there's a weight name then we will append it
+        sut.weightName = "Regular"
+        name = sut.fontName(for: .regular, compatibleWith: nil)
+        XCTAssertNotEqual(name, sut.familyName)
+        XCTAssertTrue(name.hasSuffix("-" + sut.weightName))
+
+        // If there's a suffix then we will append it
+        sut.weightName = ""
+        sut.fontNameSuffix = "Italic"
+        name = sut.fontName(for: .regular, compatibleWith: nil)
+        XCTAssertNotEqual(name, sut.familyName)
+        XCTAssertTrue(name.hasSuffix("-" + sut.fontNameSuffix))
+
+        // If there's neither then we just return the family name
+        sut.fontNameSuffix = ""
+        name = sut.fontName(for: .regular, compatibleWith: nil)
+        XCTAssertEqual(name, sut.familyName)
+        XCTAssertNil(name.firstIndex(of: "-"))
+    }
 }
 
 // We use large tuples in makeSUT()
@@ -145,4 +169,12 @@ final class MockFontFamily: FontFamily {
     let familyName: String = "MockSerifMono"
 
     var supportedWeights: [Typography.FontWeight] = Typography.FontWeight.allCases
+}
+
+final class WeightlessFontFamily: FontFamily {
+    let familyName: String = "Weightless"
+    var weightName: String = ""
+    var fontNameSuffix: String = ""
+
+    func weightName(for weight: Typography.FontWeight) -> String { weightName }
 }

--- a/Tests/YMatterTypeTests/Typography/FontFamily/HelveticaNeueFontFamilyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontFamily/HelveticaNeueFontFamilyTests.swift
@@ -1,0 +1,57 @@
+//
+//  HelveticaNeueFontFamilyTests.swift
+//  YMatterTypeTests
+//
+//  Created by Mark Pospesel on 3/2/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YMatterType
+
+final class HelveticaNeueFontFamilyTests: XCTestCase {
+    func testFont() {
+        let (families, traitCollections) = makeSUT()
+        for family in families {
+            for weight in family.supportedWeights {
+                for traitCollection in traitCollections {
+                    let pointSize = CGFloat(Int.random(in: 10...32))
+                    let font = family.font(for: weight, pointSize: pointSize, compatibleWith: traitCollection)
+                    XCTAssertEqual(font.familyName, "Helvetica Neue")
+                    XCTAssertEqual(font.pointSize, pointSize)
+                }
+            }
+        }
+    }
+
+    func testRegular() {
+        let (families, _) = makeSUT()
+        for family in families {
+            XCTAssertTrue(family.weightName(for: .regular).isEmpty)
+        }
+    }
+
+    func testUnsupportedWeights() {
+        let (families, _) = makeSUT()
+        for family in families {
+            let unsupported = Typography.FontWeight.allCases.filter { !family.supportedWeights.contains($0) }
+            for weight in unsupported {
+                XCTAssertTrue(family.weightName(for: weight).isEmpty)
+            }
+        }
+    }
+}
+
+private extension HelveticaNeueFontFamilyTests {
+    func makeSUT() -> ([FontFamily], [UITraitCollection?]) {
+        super.setUp()
+        let families: [FontFamily] = [Typography.helveticaNeue, Typography.helveticaNeueItalic]
+        let traitCollections: [UITraitCollection?] = [
+            nil,
+            UITraitCollection(legibilityWeight: .unspecified),
+            UITraitCollection(legibilityWeight: .regular),
+            UITraitCollection(legibilityWeight: .bold)
+        ]
+        return (families, traitCollections)
+    }
+}

--- a/Tests/YMatterTypeTests/Typography/FontFamily/HelveticaNeueFontFamilyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontFamily/HelveticaNeueFontFamilyTests.swift
@@ -44,7 +44,6 @@ final class HelveticaNeueFontFamilyTests: XCTestCase {
 
 private extension HelveticaNeueFontFamilyTests {
     func makeSUT() -> ([FontFamily], [UITraitCollection?]) {
-        super.setUp()
         let families: [FontFamily] = [Typography.helveticaNeue, Typography.helveticaNeueItalic]
         let traitCollections: [UITraitCollection?] = [
             nil,

--- a/Tests/YMatterTypeTests/Typography/FontFamily/SystemFontFamilyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontFamily/SystemFontFamilyTests.swift
@@ -36,7 +36,6 @@ final class SystemFontFamilyTests: XCTestCase {
 
 private extension SystemFontFamilyTests {
     func makeSUT() -> (FontFamily, [CGFloat], [UITraitCollection?]) {
-        super.setUp()
         let sut = Typography.systemFamily
         let pointSizes: [CGFloat] = [10, 12, 14, 16, 18, 24, 28, 32]
         let traitCollections: [UITraitCollection?] = [


### PR DESCRIPTION
## Introduction ##

HelveticaNeue is installed on iOS (and tvOS) devices. It has some quirks that mean we can't just use a DefaultFontFamiy for it, so a custom `FontFamily` implementation is needed.

## Purpose ##

Add a font family implementation for HelveticaNeue that handles both regular and italic.
Fix #60 

## Scope ##

* Minor change to behavior of FontFamily to handle naming fonts where there is no weight name
* Added new font family implementation
* Modified DefaultFontFamilyFactory to handle HelveticaNeue case.
* Unit tests

## 📈 Coverage ##

##### Code #####

**97.9%**

<img width="616" alt="image" src="https://user-images.githubusercontent.com/1037520/222540098-9a7ae147-f978-47d1-9b95-3cadca4d07db.png">

##### Documentation #####

**100%**

<img width="736" alt="image" src="https://user-images.githubusercontent.com/1037520/222540287-f73e6eb3-5885-4174-a7a3-edb994f6dbf0.png">
