### PR TITLE
[Issue 63] Don’t manually increase weight of scaled system fonts

### DIFF
--- a/Sources/YMatterType/Typography/FontFamily/SystemFontFamily.swift
+++ b/Sources/YMatterType/Typography/FontFamily/SystemFontFamily.swift
@@ -64,11 +64,40 @@ public struct SystemFontFamily: FontFamily {
         pointSize: CGFloat,
         compatibleWith traitCollection: UITraitCollection?
     ) -> UIFont {
-        // The system font cannot be retrieved using UIFont.font(name:size:), but
-        // instead must be created using UIFont.systemFont(ofSize:weight:)
-        let useBoldFont = isBoldTextEnabled(compatibleWith: traitCollection)
+        // When UIAccessibility.isBoldTextEnabled == true, then we don't need to manually
+        // adjust the weight because the system will do it for us.
+        let useBoldFont = isBoldTextEnabled(compatibleWith: traitCollection) && !UIAccessibility.isBoldTextEnabled
         let actualWeight = useBoldFont ? accessibilityBoldWeight(for: weight) : weight
 
+        // The system font cannot be retrieved using UIFont.font(name:size:), but
+        // instead must be created using UIFont.systemFont(ofSize:weight:)
         return UIFont.systemFont(ofSize: pointSize, weight: actualWeight.systemWeight)
+    }
+
+    /// Returns the next heavier supported weight (if any), otherwise the heaviest supported weight
+    public func accessibilityBoldWeight(for weight: Typography.FontWeight) -> Typography.FontWeight {
+        var boldWeight: Typography.FontWeight
+
+        switch weight {
+        // For 3 lightest weights, move up 1 weight
+        case .ultralight:
+            boldWeight = .thin
+        case .thin:
+            boldWeight = .light
+        case .light:
+            boldWeight = .regular
+
+        // For all remaining weights, move up 2 weights
+        case .regular:
+            boldWeight = .semibold
+        case .medium:
+            boldWeight = .bold
+        case .semibold:
+            boldWeight = .heavy
+        case .bold, .heavy, .black:
+            boldWeight = .black
+        }
+
+        return boldWeight
     }
 }

--- a/Sources/YMatterType/Typography/Typography+Font.swift
+++ b/Sources/YMatterType/Typography/Typography+Font.swift
@@ -47,6 +47,15 @@ extension Typography {
                 )
                 scaledLineHeight = metrics.scaledValue(for: lineHeight, compatibleWith: traitCollection)
             }
+        } else if fontFamily is SystemFontFamily {
+            // In case of a fixed System font, we still need to "scale" the font
+            // to adjust it to the correct traits.
+            let metrics = UIFontMetrics(forTextStyle: textStyle)
+            font = metrics.scaledFont(
+                for: font,
+                maximumPointSize: fontSize, // no change in size
+                compatibleWith: traitCollection
+            )
         }
 
         // We need to adjust the baseline so that the text will appear vertically centered
@@ -128,7 +137,7 @@ extension Typography {
 private extension Typography {
     func generateFixedFont(compatibleWith traitCollection: UITraitCollection?) -> UIFont {
         var traits = traitCollection
-        if !isFixed && fontFamily is SystemFontFamily {
+        if fontFamily is SystemFontFamily {
             // System font already considers accessibility BoldText when
             // we get the scaled font via `UIFontMetrics.scaledFont(for:compatibleWith:)`,
             // so we pass a non-bold trait collection when generating the fixed font, so

--- a/Sources/YMatterType/Typography/Typography+Font.swift
+++ b/Sources/YMatterType/Typography/Typography+Font.swift
@@ -127,6 +127,14 @@ extension Typography {
 
 private extension Typography {
     func generateFixedFont(compatibleWith traitCollection: UITraitCollection?) -> UIFont {
-        fontFamily.font(for: fontWeight, pointSize: fontSize, compatibleWith: traitCollection)
+        var traits = traitCollection
+        if !isFixed && fontFamily is SystemFontFamily {
+            // System font already considers accessibility BoldText when
+            // we get the scaled font via `UIFontMetrics.scaledFont(for:compatibleWith:)`,
+            // so we pass a non-bold trait collection when generating the fixed font, so
+            // as not to increase the font weight twice.
+            traits = UITraitCollection(legibilityWeight: .regular)
+        }
+        return fontFamily.font(for: fontWeight, pointSize: fontSize, compatibleWith: traits)
     }
 }

--- a/Tests/YMatterTypeTests/Typography/FontFamily/SystemFontFamilyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontFamily/SystemFontFamilyTests.swift
@@ -29,6 +29,60 @@ final class SystemFontFamilyTests: XCTestCase {
         let (sut, _, _) = makeSUT()
         XCTAssertTrue(sut.familyName.isEmpty)
     }
+
+    func test_accessibilityWeight_deliversCorrectWeight() {
+        let (sut, _, _) = makeSUT()
+        let lightWeights: [Typography.FontWeight] = [.ultralight, .thin, .light]
+        let midWeights: [Typography.FontWeight] = [.regular, .medium, .semibold]
+        let heavyWeights: [Typography.FontWeight] = [.bold, .heavy, .black]
+
+        for weight in lightWeights {
+            XCTAssertEqual(sut.accessibilityBoldWeight(for: weight).rawValue, weight.rawValue + 100)
+        }
+
+        for weight in midWeights {
+            XCTAssertEqual(sut.accessibilityBoldWeight(for: weight).rawValue, weight.rawValue + 200)
+        }
+
+        for weight in heavyWeights {
+            XCTAssertEqual(sut.accessibilityBoldWeight(for: weight), .black)
+        }
+    }
+
+    func test_layout_deliversCorrectFont() throws {
+        let (sut, _, traitCollections) = makeSUT()
+
+        for weight in Typography.systemFamily.supportedWeights {
+            for traitCollection in traitCollections {
+                let typography = Typography(fontFamily: sut, fontWeight: weight, fontSize: 16, lineHeight: 24)
+                let layoutDynamic = typography.generateLayout(compatibleWith: traitCollection)
+                let layoutFixed = typography.fixed.generateLayout(compatibleWith: traitCollection)
+                XCTAssertEqual(layoutDynamic.font.fontName, layoutFixed.font.fontName)
+            }
+        }
+    }
+
+    func test_layoutWithLegibilityWeightBold_deliversHeavierFont() throws {
+        // Given
+        let (sut, _, _) = makeSUT()
+        let traitRegular = UITraitCollection(legibilityWeight: .regular)
+        let traitBold = UITraitCollection(legibilityWeight: .bold)
+        var weights = Typography.systemFamily.supportedWeights
+        weights.removeLast() // don't consider .black because we cannot go heavier
+
+        for weight in weights {
+            // When
+            let typography = Typography(fontFamily: sut, fontWeight: weight, fontSize: 16, lineHeight: 24)
+            let layoutRegular = typography.generateLayout(compatibleWith: traitRegular)
+            let layoutBold = typography.generateLayout(compatibleWith: traitBold)
+
+            let weightRegular = try XCTUnwrap(self.weight(from: layoutRegular.font))
+            let weightBold = try XCTUnwrap(self.weight(from: layoutBold.font))
+
+            // Then
+            XCTAssertGreaterThan(weightBold.rawValue, weightRegular.rawValue)
+        }
+    }
 }
 
 // We use large tuples in makeSUT()
@@ -45,5 +99,34 @@ private extension SystemFontFamilyTests {
             UITraitCollection(legibilityWeight: .bold)
         ]
         return (sut, pointSizes, traitCollections)
+    }
+
+    func weight(from font: UIFont) -> Typography.FontWeight? {
+        guard let weightString = font.fontName.components(separatedBy: "-").last else {
+            return nil
+        }
+
+        switch weightString.lowercased(with: Locale(identifier: "en_US")) {
+        case "ultralight", "extralight":
+            return .ultralight
+        case "thin":
+            return .thin
+        case "light":
+            return .light
+        case "regular":
+            return .regular
+        case "medium":
+            return .medium
+        case "semibold", "demibold":
+            return .semibold
+        case "bold":
+            return .bold
+        case "heavy", "extrabold":
+            return .heavy
+        case "black":
+            return .black
+        default:
+            return nil
+        }
     }
 }


### PR DESCRIPTION
## Introduction ##

`FontFamily` moves to the next heavier weight when accessibility bold text is enabled (or the trait collections specify the `.bold` legibility weight), but the built-in Apple system font does this as well, so we ended up making typographies using the `SystemFontFamily` extra bold.

For system font family only we should not manually increase the weight to be used.

## Purpose ##

Fix #63 `SystemFontFamily` to not increase the weight twice.

## Scope ##

* Fix `SystemFontFamily`
* Adjust `Typography+Font.swift` to consider special case of system font
* Add unit test coverage

## Discussion ##

Our default behavior is to increase the font weight by 100 when accessibility bold text is enabled.
The system font increases the lightest 3 weights by 100, but the remaining weights by 200 each (up to a maximum of 900), so I updated `SystemFontFamily. accessibilityBoldWeight(weight:)` to match.

For a non-scaled system typography (`.isFixed == true`), we still need to increase the weight manually. But for scaled system typography, we do not because `UIFontMetrics.scaledFont(font:traitCollection:)` handles that automatically.

## 📱 Screenshots ##

In the first row, behavior is identical when accessibility bold text is off.
In the second row, system fonts were made much heavier when accessibility bold text is on.

| Bold Text | Before | After |
| ------------- | ------------- | ------------- |
| Off | ![ymt_63_regular_before](https://user-images.githubusercontent.com/1037520/225881902-513000f5-8c50-4c2a-8698-04339a5b911c.png) | ![ymt_63_regular_after](https://user-images.githubusercontent.com/1037520/225881907-e5c12ccb-4b16-4812-9301-1837ab441467.png) |
| On | ![ymt_63_bold_before](https://user-images.githubusercontent.com/1037520/225881898-be607769-b693-4382-acf5-29d7f824f844.png) | ![ymt_63_bold_after](https://user-images.githubusercontent.com/1037520/225881905-7f486d8f-beee-46ae-ae26-d7531a930ba4.png) |

## 📈 Coverage ##

##### Code #####

97.9%
<img width="633" alt="image" src="https://user-images.githubusercontent.com/1037520/225883242-263192a4-c46c-4364-adf3-554ade759b51.png">

##### Documentation #####

100%
<img width="598" alt="image" src="https://user-images.githubusercontent.com/1037520/225882790-3705180a-2c9c-4531-ac95-9ca1c231b3b5.png">
