### PR TITLE
[Issue-69] Make buildAttributes public

### DIFF
--- a/Sources/YMatterType/Typography/TypographyLayout.swift
+++ b/Sources/YMatterType/Typography/TypographyLayout.swift
@@ -79,7 +79,7 @@ public extension TypographyLayout {
     /// Style plain text using this layout
     /// - Parameters:
     ///   - text: the text to style
-    ///   - isSingleLine: `true` for single line text, `false` for potentially multi-line text.
+    ///   - lineMode: line mode of the text.
     ///    Paragraph styles will not be applied to single line text.
     ///   - additionalAttributes: any additional attributes to apply
     ///   (e.g. `UITextView` requires `.foregroundColor`), default = `[:]`
@@ -98,8 +98,8 @@ public extension TypographyLayout {
 
     /// Style attributed text using this layout
     /// - Parameters:
-    ///   - text: the text to style
-    ///   - isSingleLine: `true` for single line text, `false` for potentially multi-line text.
+    ///   - attributedText: the attrubuted text to style
+    ///   - lineMode: line mode of the text.
     ///    Paragraph styles will not be applied to single line text.
     ///   - additionalAttributes: any additional attributes to apply
     ///   (e.g. `UITextView` requires `.foregroundColor`), default = `[:]`
@@ -112,12 +112,20 @@ public extension TypographyLayout {
         let attributes = buildAttributes(startingWith: additionalAttributes, lineMode: lineMode)
         return attributedText.textCase(textCase).attributedString(with: attributes)
     }
-}
 
-private extension TypographyLayout {
+    /// Generates the text attributes needed to apply this typographical layout.
+    ///
+    /// These attributes may change (because the font may change) any time there is a change in
+    /// content size category (Dynamic Type) or legibility weight (Accessibility Bold Text).
+    /// - Parameters:
+    ///   - additionalAttributes: any additional attributes to combine with the typographical attributes.
+    ///   	Default = `[:]`
+    ///   - lineMode: line mode of the text. Default = `.single`.
+    ///    Paragraph styles will not be applied to single line text.
+    /// - Returns: the dictionary of attributes needed to style the text.
     func buildAttributes(
-        startingWith additionalAttributes: [NSAttributedString.Key: Any],
-        lineMode: Typography.LineMode
+        startingWith additionalAttributes: [NSAttributedString.Key: Any] = [:],
+        lineMode: Typography.LineMode = .single
     ) -> [NSAttributedString.Key: Any] {
         var attributes = additionalAttributes
         if case let .multi(textAlignment, lineBreakMode) = lineMode {

--- a/Tests/YMatterTypeTests/Typography/TypographyLayoutTests.swift
+++ b/Tests/YMatterTypeTests/Typography/TypographyLayoutTests.swift
@@ -110,6 +110,58 @@ final class TypographyLayoutTests: XCTestCase {
         // we expect it to have paragraph style
         XCTAssertNotNil(styled.attribute(.paragraphStyle, at: 0, effectiveRange: nil))
     }
+
+    func test_buildAttributes_defaultDeliversFontAttributeOnly() {
+        let sut = makeSUT()
+        let attributes = sut.buildAttributes()
+
+        XCTAssertEqual(sut.font, attributes[.font] as? UIFont)
+        XCTAssertNil(attributes[.paragraphStyle])
+        XCTAssertNil(attributes[.kern])
+        XCTAssertNil(attributes[.underlineStyle])
+        XCTAssertNil(attributes[.strikethroughStyle])
+        XCTAssertNil(attributes[.baselineOffset])
+    }
+
+    func test_buildAttributes_singleLineDeliversNoParagraphStyles() {
+        let sut = makeSUT()
+        let attributes = sut.buildAttributes(lineMode: .single)
+
+        XCTAssertNil(attributes[.paragraphStyle])
+    }
+
+    func test_buildAttributes_multiLineDeliversParagraphStyles() throws {
+        let sut = makeSUT()
+        let attributes = sut.buildAttributes(lineMode: .multi(alignment: .natural, lineBreakMode: .byWordWrapping))
+
+        let paragraphStyle = try XCTUnwrap(attributes[.paragraphStyle] as? NSParagraphStyle)
+        XCTAssertEqual(paragraphStyle.minimumLineHeight, sut.lineHeight)
+        XCTAssertEqual(paragraphStyle.maximumLineHeight, sut.lineHeight)
+        XCTAssertEqual(paragraphStyle.lineBreakMode, .byWordWrapping)
+        XCTAssertEqual(sut.baselineOffset, attributes[.baselineOffset] as? CGFloat)
+    }
+
+    func test_buildAttributes_deliversKernAttribute() {
+        let letterSpacing = CGFloat(Int.random(in: 1...24)) / 10.0
+        let sut = makeSUT(letterSpacing: letterSpacing)
+        let attributes = sut.buildAttributes()
+
+        XCTAssertEqual(letterSpacing, attributes[.kern] as? CGFloat)
+    }
+
+    func test_buildAttributes_deliversUnderlineAttributes() {
+        let sut = makeSUT(textDecoration: .underline)
+        let attributes = sut.buildAttributes()
+
+        XCTAssertEqual(NSUnderlineStyle.single.rawValue, attributes[.underlineStyle] as? Int)
+    }
+
+    func test_buildAttributes_deliversStrikethroughAttributes() {
+        let sut = makeSUT(textDecoration: .strikethrough)
+        let attributes = sut.buildAttributes()
+
+        XCTAssertEqual(NSUnderlineStyle.single.rawValue, attributes[.strikethroughStyle] as? Int)
+    }
 }
 
 private extension TypographyLayoutTests {


### PR DESCRIPTION
## Introduction ##

This currently private method on `TypographyLayout` could be used to style any UIKit view that allows you to set default text attributes.

## Purpose ##

Fix #69: Make this method public, give it sensible defaults, cover it in documentation comments, and unit tests.

## Scope ##

* Modify TypographyLayout
* Add unit tests

## Discussion ##

Also fixes #66: which were documentation comments for sibling methods in `TypographyLayout`.

## 📈 Coverage ##

##### Code #####

97.9%
<img width="633" alt="image" src="https://user-images.githubusercontent.com/1037520/225917414-80678555-27ee-424c-8bfc-5662fd4f7889.png">

##### Documentation #####

100%
<img width="576" alt="image" src="https://user-images.githubusercontent.com/1037520/225917516-f2b39e1c-1080-4bfa-99a7-7a01c4a5aaf7.png">
