### PR TITLE
[Issue-64] Initialize FontWeight from string

### DIFF
--- a/Sources/YMatterType/Typography/Typography+Enums.swift
+++ b/Sources/YMatterType/Typography/Typography+Enums.swift
@@ -36,6 +36,36 @@ extension Typography {
         case heavy = 800
         /// black weight (900)
         case black = 900
+
+        /// Creates a new instance from a string.
+        ///
+        /// This will be useful for converting Figma tokens to `Typography` objects.
+        /// Common synonyms will be accepted, e.g. both "SemiBold" and "DemiBold" map to `.semibold`.
+        /// - Parameter weightName: the case-insensitive weight name, e.g. "Bold"
+        init?(_ weightName: String) {
+            switch weightName.lowercased(with: Locale(identifier: "en_US")) {
+            case "ultralight", "extralight":
+                self = .ultralight
+            case "thin":
+                self = .thin
+            case "light":
+                self = .light
+            case "regular":
+                self = .regular
+            case "medium":
+                self = .medium
+            case "semibold", "demibold":
+                self = .semibold
+            case "bold":
+                self = .bold
+            case "heavy", "extrabold", "ultrabold":
+                self = .heavy
+            case "black":
+                self = .black
+            default:
+                return nil
+            }
+        }
     }
 
     /// Capitalization to be applied to user-facing text

--- a/Tests/YMatterTypeTests/Typography/Typography+EnumTests.swift
+++ b/Tests/YMatterTypeTests/Typography/Typography+EnumTests.swift
@@ -1,0 +1,51 @@
+//
+//  Typography+EnumTests.swift
+//  YMatterTypeTests
+//
+//  Created by Mark Pospesel on 3/17/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YMatterType
+
+final class TypographyEnumTests: XCTestCase {
+    func test_fontWeightInit_garbageReturnsNil() {
+        ["", "nonsense", "garbage", "not a weight"].forEach {
+            XCTAssertNil(Typography.FontWeight($0))
+        }
+    }
+
+    func test_fontWeightInit_isCaseInsensitive() {
+        ["Regular", "regular", "REGULAR", "ReGuLaR"].forEach {
+            XCTAssertEqual(Typography.FontWeight($0), .regular)
+        }
+
+        ["Semibold", "semibold", "SEMIBOLD", "SemiBold"].forEach {
+            XCTAssertEqual(Typography.FontWeight($0), .semibold)
+        }
+    }
+
+    func test_fontWeightInit_acceptsSynonyms() {
+        ["ExtraLight", "UltraLight"].forEach {
+            XCTAssertEqual(Typography.FontWeight($0), .ultralight)
+        }
+
+        ["SemiBold", "DemiBold"].forEach {
+            XCTAssertEqual(Typography.FontWeight($0), .semibold)
+        }
+
+        ["Heavy", "ExtraBold", "UltraBold"].forEach {
+            XCTAssertEqual(Typography.FontWeight($0), .heavy)
+        }
+    }
+
+    func test_fontWeightInit_acceptsFontFamilyWeightNames() {
+        let sut = DefaultFontFamily(familyName: "Any")
+
+        for weight in sut.supportedWeights {
+            let weightName = sut.weightName(for: weight)
+            XCTAssertEqual(Typography.FontWeight(weightName), weight)
+        }
+    }
+}


### PR DESCRIPTION
## Introduction ##

Figma exports text style weights as strings. To automate the creation of `Typography` objects from tokens, we need to be able to map from `String` to `Typography.FontWeight`.

## Purpose ##

Fix #64 Add a failable initializer to `Typography.FontWeight` that accepts a `String`.

## Scope ##

* Add new `init?` method to `FontWeight` enum
* Add unit tests

## Discussion ##

We need this for Figma token automation.

## 📈 Coverage ##

##### Code #####

97.9%
<img width="645" alt="image" src="https://user-images.githubusercontent.com/1037520/225928409-c4b1a422-afb5-4d66-ad74-6d6121907ecb.png">

##### Documentation #####

100%
<img width="575" alt="image" src="https://user-images.githubusercontent.com/1037520/225928253-37982edb-09ab-4b5e-9363-8318db4684e3.png">

