### PR TITLE
[Issue-68] Fix unit tests that fail in Bold Text mode

### DIFF
--- a/Sources/YMatterType/Typography/Typography+Enums.swift
+++ b/Sources/YMatterType/Typography/Typography+Enums.swift
@@ -42,7 +42,7 @@ extension Typography {
         /// This will be useful for converting Figma tokens to `Typography` objects.
         /// Common synonyms will be accepted, e.g. both "SemiBold" and "DemiBold" map to `.semibold`.
         /// - Parameter weightName: the case-insensitive weight name, e.g. "Bold"
-        init?(_ weightName: String) {
+        public init?(_ weightName: String) {
             switch weightName.lowercased(with: Locale(identifier: "en_US")) {
             case "ultralight", "extralight":
                 self = .ultralight

--- a/Tests/YMatterTypeTests/Elements/TypographyButtonTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyButtonTests.swift
@@ -160,7 +160,7 @@ final class TypographyButtonTests: TypographyElementTests {
             sut.typography.lineHeight * 2 + sut.contentEdgeInsets.vertical
         )
 
-        let fontFamily = DefaultFontFamily(familyName: "AvenirNext")
+        let fontFamily = AvenirNextFontFamily()
         let typography = Typography(
             fontFamily: fontFamily,
             fontWeight: .bold,
@@ -423,7 +423,7 @@ final class TypographyButtonTests: TypographyElementTests {
 private extension TypographyButtonTests {
     func makeSUT(spacing: CGFloat = 0, file: StaticString = #filePath, line: UInt = #line) -> MockButton {
         let typography = Typography(
-            familyName: "NotoSans",
+            fontFamily: Typography.notoSans,
             fontWeight: .regular,
             fontSize: 16,
             lineHeight: 24,

--- a/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyLabelTests.swift
@@ -144,7 +144,7 @@ final class TypographyLabelTests: TypographyElementTests {
         // we expect label height to be a multiple of the old lineHeight
         XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight * 2)
 
-        let fontFamily = DefaultFontFamily(familyName: "AvenirNext")
+        let fontFamily = AvenirNextFontFamily()
         let typography = Typography(
             fontFamily: fontFamily,
             fontWeight: .bold,
@@ -364,7 +364,7 @@ private extension TypographyLabelTests {
         line: UInt = #line
     ) -> MockLabel {
         let typography = Typography(
-            familyName: "NotoSans",
+            fontFamily: Typography.notoSans,
             fontWeight: .regular,
             fontSize: 24,
             lineHeight: 32,

--- a/Tests/YMatterTypeTests/Elements/TypographyTextFieldTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyTextFieldTests.swift
@@ -83,7 +83,7 @@ final class TypographyTextFieldTests: TypographyElementTests {
         // we expect text field height to equal the old lineHeight
         XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight)
 
-        let fontFamily = DefaultFontFamily(familyName: "AvenirNext")
+        let fontFamily = AvenirNextFontFamily()
         let typography = Typography(
             fontFamily: fontFamily,
             fontWeight: .bold,
@@ -211,7 +211,7 @@ final class TypographyTextFieldTests: TypographyElementTests {
         XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight)
 
         // changing the typograhy will restyle the attributed text
-        let fontFamily = DefaultFontFamily(familyName: "AvenirNext")
+        let fontFamily = AvenirNextFontFamily()
         sut.typography = Typography(
             fontFamily: fontFamily,
             fontWeight: .bold,
@@ -299,7 +299,7 @@ final class TypographyTextFieldTests: TypographyElementTests {
 private extension TypographyTextFieldTests {
     func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> MockTextField {
         let typography = Typography(
-            familyName: "NotoSans",
+            fontFamily: Typography.notoSans,
             fontWeight: .regular,
             fontSize: 13,
             lineHeight: 20,

--- a/Tests/YMatterTypeTests/Elements/TypographyTextViewTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyTextViewTests.swift
@@ -109,7 +109,7 @@ final class TypographyTextViewTests: TypographyElementTests {
         // we expect label height to be a multiple of the old lineHeight
         XCTAssertEqual(sut.intrinsicContentSize.height, sut.typography.lineHeight * 2)
 
-        let fontFamily = DefaultFontFamily(familyName: "AvenirNext")
+        let fontFamily = AvenirNextFontFamily()
         let typography = Typography(
             fontFamily: fontFamily,
             fontWeight: .bold,
@@ -302,7 +302,7 @@ final class TypographyTextViewTests: TypographyElementTests {
 private extension TypographyTextViewTests {
     func makeSUT(spacing: CGFloat = 0, file: StaticString = #filePath, line: UInt = #line) -> MockTextView {
         let typography = Typography(
-            familyName: "NotoSans",
+            fontFamily: Typography.notoSans,
             fontWeight: .regular,
             fontSize: 22,
             lineHeight: 28,

--- a/Tests/YMatterTypeTests/Typography/TypogaphyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/TypogaphyTests.swift
@@ -60,6 +60,31 @@ struct NotoSansFontFamily: FontFamily {
     var supportedWeights: [Typography.FontWeight] { [.regular] }
 }
 
+struct AvenirNextFontFamily: FontFamily {
+    let familyName = "AvenirNext"
+
+    var supportedWeights: [Typography.FontWeight] { [.ultralight, .regular, .medium, .semibold, .bold, .heavy] }
+
+    func weightName(for weight: Typography.FontWeight) -> String {
+        switch weight {
+        case .ultralight:
+            return "UltraLight"
+        case .regular:
+            return "Regular"
+        case .medium:
+            return "Medium"
+        case .semibold:
+            return "DemiBold"
+        case .bold:
+            return "Bold"
+        case .heavy:
+            return "Heavy"
+        case .thin, .light, .black:
+            return "" // these 3 weights are not installed
+        }
+    }
+}
+
 extension Typography {
     static let notoSans = NotoSansFontFamily()
 }


### PR DESCRIPTION
## Introduction ##

While working on another issue, I noticed that some unit tests would fail if the device (or simulator) the tests were running on had the Accessibility Bold Text feature enabled.

## Purpose ##

Fix #68 Clean up the unit tests so that they pass whether Bold Text is enabled or not.

## Scope ##

* Changes to test cases only

## Discussion ##

This wasn't affecting CI/CD or anything because those simulators don't have Bold Text enabled, but it is a flakiness that should be cleaned up and will help ensure that our code is robust.

## 📈 Coverage ##

##### Code #####

Remains unchanged at 97.9% (didn't anticipate any code coverage changes since I didn't add or remove any tests, only provided different font families to test).
<img width="552" alt="image" src="https://user-images.githubusercontent.com/1037520/225931747-59a1b64f-068f-4bd8-b624-1fa6fa8a860e.png">

##### Documentation #####

Documentation coverage remains unchanged at 100% because this PR only affects unit test cases.