### PR TITLE
Increase test coverage for TextStyleLabel and TypographyLabelRepresentable

### DIFF
--- a/Sources/YMatterType/Elements/Representables/TypographyLabelRepresentable.swift
+++ b/Sources/YMatterType/Elements/Representables/TypographyLabelRepresentable.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 /// A wrapper for a UIKit TypographyLabel view that allows to integrate that view into a SwiftUI view hierarchy.
-struct TypographyLabelRepresentable: UIViewRepresentable {
+struct TypographyLabelRepresentable {
     /// The type of view to present.
     typealias UIViewType = TypographyLabel
 
@@ -21,7 +21,9 @@ struct TypographyLabelRepresentable: UIViewRepresentable {
     
     /// A closure that gets called on the init and refresh of the View
     var configureTextStyleLabel: ((TypographyLabel) -> Void)?
+}
 
+extension TypographyLabelRepresentable: UIViewRepresentable {
     /// Creates the view object and configures its initial state.
     ///
     /// - Parameter context: A context structure containing information about
@@ -29,6 +31,10 @@ struct TypographyLabelRepresentable: UIViewRepresentable {
     ///
     /// - Returns: `TypographyLabel` view configured with the provided information.
     func makeUIView(context: Context) -> TypographyLabel {
+        getLabel()
+    }
+
+    func getLabel() -> TypographyLabel {
         let label = TypographyLabel(typography: typography)
         label.text = text
         
@@ -49,8 +55,12 @@ struct TypographyLabelRepresentable: UIViewRepresentable {
     ///   - context: A context structure containing information about the current
     ///     state of the system.
     func updateUIView(_ uiView: TypographyLabel, context: Context) {
-        uiView.typography = typography
-        uiView.text = text
-        configureTextStyleLabel?(uiView)
+        updateLabel(uiView)
+    }
+
+    func updateLabel(_ label: TypographyLabel) {
+        label.typography = typography
+        label.text = text
+        configureTextStyleLabel?(label)
     }
 }

--- a/Sources/YMatterType/Elements/TextStyleLabel.swift
+++ b/Sources/YMatterType/Elements/TextStyleLabel.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 /// A singe line text label that supports `Typography` for SwiftUI.
-public struct TextStyleLabel: View {
+public struct TextStyleLabel {
     /// The text that the label displays.
     var text: String
     
@@ -19,16 +19,6 @@ public struct TextStyleLabel: View {
     /// A closure that gets called on the init and refresh of the View
     /// This closure allows you to provide additional configuration to the `TypographyLabel`
     var configureTextStyleLabel: ((TypographyLabel) -> Void)?
-
-    /// The content and behavior of the view.
-    public var body: some View {
-        TypographyLabelRepresentable(
-            text: text,
-            typography: typography,
-            configureTextStyleLabel: configureTextStyleLabel
-        )
-        .fixedSize(horizontal: false, vertical: true)
-    }
 
     /// Initializes a `TextStyleLabel` instance with the specified parameters
     /// - Parameters:
@@ -40,8 +30,24 @@ public struct TextStyleLabel: View {
         typography: Typography,
         configuration: ((TypographyLabel) -> Void)? = nil
     ) {
-        self.typography = typography
         self.text = text
+        self.typography = typography
         self.configureTextStyleLabel = configuration
+    }
+}
+
+extension TextStyleLabel: View {
+    /// The content and behavior of the view.
+    public var body: some View {
+        getLabel()
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    func getLabel() -> some View {
+        TypographyLabelRepresentable(
+            text: text,
+            typography: typography,
+            configureTextStyleLabel: configureTextStyleLabel
+        )
     }
 }

--- a/Tests/YMatterTypeTests/Elements/Representables/TypographyLabelRepresentableTests.swift
+++ b/Tests/YMatterTypeTests/Elements/Representables/TypographyLabelRepresentableTests.swift
@@ -1,0 +1,64 @@
+//
+//  TypographyLabelRepresentableTests.swift
+//  YMatterTypeTests
+//
+//  Created by Mark Pospesel on 3/20/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YMatterType
+
+final class TypographyLabelRepresentableTests: XCTestCase {
+    enum Constants {
+        static let helloWorldText = "Hello, World"
+        static let goodbyeText = "Goodbye!"
+        static let fontSize = CGFloat.random(in: 18...36)
+        static let textColor: UIColor = .systemPurple
+    }
+
+    func test_getLabel_deliversLabel() {
+        // Given
+        let text = Constants.helloWorldText
+        let typography: Typography = .smallBody.fontSize(Constants.fontSize)
+        let textColor = Constants.textColor
+        let sut = TypographyLabelRepresentable(text: text, typography: typography) { label in
+            label.textColor = textColor
+        }
+
+        // When
+        let label = sut.getLabel()
+
+        // Then
+        XCTAssertEqual(label.text, text)
+        XCTAssertTypographyEqual(label.typography, typography)
+        XCTAssertEqual(label.numberOfLines, 1)
+        XCTAssertEqual(label.textColor, textColor)
+    }
+
+    func test_updateLabel_updatesLabel() {
+        // Given
+        let text = Constants.goodbyeText
+        let typography: Typography = .bodyBold.fontSize(Constants.fontSize)
+        let textColor = Constants.textColor
+        var sut = TypographyLabelRepresentable(text: Constants.helloWorldText, typography: .smallBody)
+        let label = sut.getLabel()
+        XCTAssertNotEqual(label.text, text)
+        XCTAssertNotEqual(label.typography.fontSize, typography.fontSize)
+        XCTAssertNotEqual(label.typography.fontWeight, typography.fontWeight)
+        XCTAssertNotEqual(label.textColor, textColor)
+
+        // When
+        sut.text = text
+        sut.typography = typography
+        sut.configureTextStyleLabel = { label in
+            label.textColor = textColor
+        }
+        sut.updateLabel(label)
+
+        // Then
+        XCTAssertEqual(label.text, text)
+        XCTAssertTypographyEqual(label.typography, typography)
+        XCTAssertEqual(label.textColor, textColor)
+    }
+}

--- a/Tests/YMatterTypeTests/Elements/TextStyleLabelTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TextStyleLabelTests.swift
@@ -15,10 +15,9 @@ final class TextStyleLabelTests: XCTestCase {
         static let fontSize = CGFloat.random(in: 10...60)
     }
     
-    func testTextStyleLabelSingleLine() throws {
-        let fontSize = Constants.fontSize
-        let expectedTypography = Typography.systemLabel.fontSize(fontSize)
+    func testTextStyleLabelSingleLine() {
         let expectedText = Constants.helloWorldText
+        let expectedTypography = Typography.systemLabel.fontSize(Constants.fontSize)
 
         // Given a TextStyleLabel with a single line of text
         let sut = TextStyleLabel(
@@ -36,8 +35,8 @@ final class TextStyleLabelTests: XCTestCase {
         XCTAssertEqual(sut.text, expectedText)
         
         // we expect the font to match the expected
-        XCTAssertEqual(sut.typography.fontSize, fontSize)
-        
+        XCTAssertTypographyEqual(sut.typography, expectedTypography)
+
         // we expect the configuration closusure to update the label
         let labelToUpdate = TypographyLabel(typography: expectedTypography)
         XCTAssertNotEqual(labelToUpdate.lineBreakMode, .byTruncatingMiddle)
@@ -46,34 +45,21 @@ final class TextStyleLabelTests: XCTestCase {
         XCTAssertEqual(labelToUpdate.lineBreakMode, .byTruncatingMiddle)
     }
 
-    func testTypographyLabelRepresentable() throws {
-        let fontSize = Constants.fontSize
-
-        let expectedTypography = Typography.systemLabel.fontSize(fontSize)
+    func test_getLabel_deliversRepresentable() throws {
         let expectedText = Constants.helloWorldText
+        let expectedTypography = Typography.systemLabel.fontSize(Constants.fontSize)
 
-        // Given a TypographyLabelRepresentable with a single line of text
-        let sut = TypographyLabelRepresentable(
-            text: expectedText,
-            typography: expectedTypography,
-            configureTextStyleLabel: { (label: TypographyLabel) in
-                label.textColor = .yellow
-            }
+        // Given a TextStyleLabel with a single line of text
+        let sut = TextStyleLabel(
+            expectedText,
+            typography: expectedTypography
         )
-        // we expect a value
-        XCTAssertNotNil(sut)
-        
-        // we expect the text to match the expected
-        XCTAssertEqual(sut.text, expectedText)
-        
-        // we expect the font to match the expected
-        XCTAssertEqual(sut.typography.fontSize, fontSize)
-        
-        // we expect the configuration closusure to update the label
-        let labelToUpdate = TypographyLabel(typography: expectedTypography)
-        XCTAssertNotEqual(labelToUpdate.textColor, .yellow)
-        
-        sut.configureTextStyleLabel?(labelToUpdate)
-        XCTAssertEqual(labelToUpdate.textColor, .yellow)
+
+        // When
+        let label = try XCTUnwrap(sut.getLabel() as? TypographyLabelRepresentable)
+
+        // Then
+        XCTAssertEqual(label.text, expectedText)
+        XCTAssertTypographyEqual(label.typography, expectedTypography)
     }
 }

--- a/Tests/YMatterTypeTests/Helpers/XCTestCase+TypographyEquatable.swift
+++ b/Tests/YMatterTypeTests/Helpers/XCTestCase+TypographyEquatable.swift
@@ -1,0 +1,35 @@
+//
+//  XCTestCase+TypographyEquatable.swift
+//  YMatterTypeTests
+//
+//  Created by Mark Pospesel on 3/21/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YMatterType
+
+extension XCTestCase {
+    /// Compares two typographies and asserts if they are not equal.
+    ///
+    /// `Typography` does not conform to `Equatable` because `fontFamily` is just a protocol
+    /// that is itself not `Equatable`. We can however compare some properties of `FontFamily` as
+    /// well as all the other properties of `Typography`.
+    /// - Parameters:
+    ///   - lhs: the first typography to compare
+    ///   - rh2: the second typography to compare
+    func XCTAssertTypographyEqual(_ lhs: Typography, _ rh2: Typography) {
+        XCTAssertEqual(lhs.fontFamily.familyName, rh2.fontFamily.familyName)
+        XCTAssertEqual(lhs.fontFamily.fontNameSuffix, rh2.fontFamily.fontNameSuffix)
+        XCTAssertEqual(lhs.fontFamily.supportedWeights, rh2.fontFamily.supportedWeights)
+        XCTAssertEqual(lhs.fontWeight, rh2.fontWeight)
+        XCTAssertEqual(lhs.fontSize, rh2.fontSize)
+        XCTAssertEqual(lhs.lineHeight, rh2.lineHeight)
+        XCTAssertEqual(lhs.letterSpacing, rh2.letterSpacing)
+        XCTAssertEqual(lhs.paragraphIndent, rh2.paragraphIndent)
+        XCTAssertEqual(lhs.paragraphSpacing, rh2.paragraphSpacing)
+        XCTAssertEqual(lhs.textDecoration, rh2.textDecoration)
+        XCTAssertEqual(lhs.textStyle, rh2.textStyle)
+        XCTAssertEqual(lhs.isFixed, rh2.isFixed)
+    }
+}


### PR DESCRIPTION
## Introduction ##

The two files that implement our SwiftUI version of typography label did not have good unit test coverage. That's because for `View` you're not supposed to directly call `body` from your unit tests. The same applies to `UIViewRepresentable` and `makeUIView(context:)` and `updateUIView(uiView:context:)` (also we don't have a context to pass in unit tests).

What we can do though is extract the majority of the body of these methods to separate methods that we _can_ test.

## Purpose ##

Fix #74 Refactor `TextStyleLabel` and `TypographyLabelRepresentable` to be more testable, and then add the tests.

## Scope ##

* Refactor `TextStyleLabel`
* Refactor `TypographyLabelRepresentable`
* Add unit tests

## Discussion ##

In addition to extracting the main bulk of `TextStyleLabel.body` and `TypographyLabelRepresentable.makeUIView()` and `updateUIView()`, I also moved the conformance to `View` and `UIViewRepresentable` to extensions of those structs (in accordance with our Style Guide).

I also added an XCTestCase extension to assist in testing equality between two typography objects (`Typography` does not conform to `Equatable` because its `fontFamily` property is itself a protocol and so not `Equatable`).

## 📈 Coverage ##

##### Code #####

| Before | After |
| ------------- | ------------- |
| 98.0% | 99.1% |
| <img width="625" alt="image" src="https://user-images.githubusercontent.com/1037520/226613702-77ebddbb-7794-4e90-98ab-4b87676619ff.png"> | <img width="625" alt="image" src="https://user-images.githubusercontent.com/1037520/226613340-ad5d5ce8-6ce2-4058-8583-007c7a7ca2d2.png"> |

##### Documentation #####

100%
<img width="576" alt="image" src="https://user-images.githubusercontent.com/1037520/226612766-f8179521-875d-483e-a090-af83cc8cb5c6.png">
