### PR TITLE
[CM-1267] String size calculation

### DIFF
--- a/Sources/YMatterType/Extensions/Foundation/String+textSize.swift
+++ b/Sources/YMatterType/Extensions/Foundation/String+textSize.swift
@@ -1,0 +1,39 @@
+//
+//  String+textSize.swift
+//  YMatterType
+//
+//  Created by Sahil Saini on 27/03/23.
+//  Copyright © 2022 Y Media Labs. All rights reserved.
+//
+
+import UIKit
+import Foundation
+
+extension String {
+    /// Returns size of the string
+    /// - Parameters:
+    ///   - typography: Typography to be used to calculate string size
+    ///   - traitCollection: Trait collection to apply
+    /// - Returns: Size of the string
+    public func size(
+        withTypography typography: Typography,
+        compatibleWith traitCollection: UITraitCollection?
+    ) -> CGSize {
+        let layout = typography.generateLayout(compatibleWith: traitCollection)
+        let valueSize = self.size(withFont: layout.font)
+        return CGSize(
+            width: valueSize.width,
+            height: max(valueSize.height, layout.lineHeight)
+        )
+    }
+
+    private func size(withFont font: UIFont) -> CGSize {
+        let scale = UIScreen.main.scale
+        let fontAttributes = [NSAttributedString.Key.font: font]
+        let size = size(withAttributes: fontAttributes)
+        return CGSize(
+            width: ceil(size.width * scale) / scale,
+            height: ceil(size.height * scale) / scale
+        )
+    }
+}

--- a/Sources/YMatterType/Extensions/Foundation/String+textSize.swift
+++ b/Sources/YMatterType/Extensions/Foundation/String+textSize.swift
@@ -7,14 +7,13 @@
 //
 
 import UIKit
-import Foundation
 
 extension String {
-    /// Returns size of the string
+    /// Calculates the size of the string rendered with the specified typography.
     /// - Parameters:
-    ///   - typography: Typography to be used to calculate string size
-    ///   - traitCollection: Trait collection to apply
-    /// - Returns: Size of the string
+    ///   - typography: the typography to be used to calculate the string size
+    ///   - traitCollection: the trait collection to apply
+    /// - Returns: the size of the string
     public func size(
         withTypography typography: Typography,
         compatibleWith traitCollection: UITraitCollection?
@@ -27,8 +26,25 @@ extension String {
         )
     }
 
-    private func size(withFont font: UIFont) -> CGSize {
-        let scale = UIScreen.main.scale
+    /// Calculates the size of the string rendered with the specified font.
+    ///
+    /// The returned size will be rounded up to the nearest pixel in both width and height.
+    /// - Parameters:
+    ///   - font: the font to be used to calculate the string size
+    ///   - traitCollection: the trait collection to apply (used for `displayScale`)
+    /// - Returns: the size of the string
+    public func size(
+        withFont font: UIFont,
+        compatibleWith traitCollection: UITraitCollection? = nil
+    ) -> CGSize {
+        let scale: CGFloat
+        if let displayScale = traitCollection?.displayScale,
+           displayScale != 0.0 {
+            scale = displayScale
+        } else {
+            scale = UIScreen.main.scale
+        }
+        
         let fontAttributes = [NSAttributedString.Key.font: font]
         let size = size(withAttributes: fontAttributes)
         return CGSize(

--- a/Tests/YMatterTypeTests/Extensions/Foundation/String+textSizeTests.swift
+++ b/Tests/YMatterTypeTests/Extensions/Foundation/String+textSizeTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class StringTextSizeTests: XCTestCase {
     func test_sizeWithFont_deliversRoundedValues() {
         // Given
-        let scale = CGFloat(Int.random(in: 1...3))
+        let scale = getScale()
         let pointSize = CGFloat(Int.random(in: 10...24))
         let traits = UITraitCollection(displayScale: scale)
         let font = UIFont.systemFont(ofSize: pointSize, weight: .regular)
@@ -29,7 +29,7 @@ final class StringTextSizeTests: XCTestCase {
 
     func test_sizeWithTypography_deliversRoundedValues() throws {
         // Given
-        let scale = CGFloat(Int.random(in: 1...3))
+        let scale = getScale()
         let traits = UITraitCollection(displayScale: scale)
         let typography = try XCTUnwrap(getTypographies().randomElement())
         let sut = "Hello"
@@ -63,6 +63,7 @@ final class StringTextSizeTests: XCTestCase {
         XCTAssertEqual(size.height, typography.lineHeight)
     }
 
+#if !os(tvOS)
     func test_sizeWithTypography_deliversScaledSize() throws {
         // Given
         let typography = try XCTUnwrap(getTypographies().randomElement())
@@ -75,6 +76,7 @@ final class StringTextSizeTests: XCTestCase {
         // Then
         XCTAssertGreaterThan(size.height, typography.lineHeight)
     }
+#endif
 
     func test_longerStrings_deliverGreaterWidths() {
         // Given
@@ -120,6 +122,16 @@ final class StringTextSizeTests: XCTestCase {
 }
 
 extension StringTextSizeTests {
+    func getScale() -> CGFloat {
+        let scale: CGFloat
+#if os(tvOS)
+        scale = UIScreen.main.scale
+#else
+        scale = CGFloat(Int.random(in: 1...3))
+#endif
+        return scale
+    }
+
     func getTypographies() -> [Typography] {
         var typographies: [Typography] = [.systemButton, .systemLabel]
 #if !os(tvOS)

--- a/Tests/YMatterTypeTests/Extensions/Foundation/String+textSizeTests.swift
+++ b/Tests/YMatterTypeTests/Extensions/Foundation/String+textSizeTests.swift
@@ -16,7 +16,7 @@ final class StringTextSizeTests: XCTestCase {
             fontWeight: .bold,
             fontSize: 24,
             lineHeight: 32,
-            textStyle: .largeTitle
+            textStyle: .callout
         )
         let sut = "testString"
         // When
@@ -33,12 +33,12 @@ final class StringTextSizeTests: XCTestCase {
             fontWeight: .bold,
             fontSize: 24,
             lineHeight: 32,
-            textStyle: .largeTitle
+            textStyle: .body
         )
         let sut1 = "testString1"
         let sut2 = "testString"
         // When
-        let sutSize1 = sut1.size(withTypography: typography, compatibleWith: nil)
+        let sutSize1 = sut1.size(withTypography: typography, compatibleWith: UITraitCollection.default)
         let sutSize2 = sut2.size(withTypography: typography, compatibleWith: nil)
         // Then
         XCTAssertGreaterThan(sutSize1.height, 0)
@@ -54,7 +54,7 @@ final class StringTextSizeTests: XCTestCase {
             fontWeight: .bold,
             fontSize: 24,
             lineHeight: 32,
-            textStyle: .largeTitle
+            textStyle: .caption1
         )
         let sut = ""
         // When

--- a/Tests/YMatterTypeTests/Extensions/Foundation/String+textSizeTests.swift
+++ b/Tests/YMatterTypeTests/Extensions/Foundation/String+textSizeTests.swift
@@ -9,24 +9,74 @@ import XCTest
 @testable import YMatterType
 
 final class StringTextSizeTests: XCTestCase {
-    func testHeightNotZero() {
+    func test_sizeWithFont_deliversRoundedValues() {
+        // Given
+        let scale = CGFloat(Int.random(in: 1...3))
+        let pointSize = CGFloat(Int.random(in: 10...24))
+        let traits = UITraitCollection(displayScale: scale)
+        let font = UIFont.systemFont(ofSize: pointSize, weight: .regular)
+        let sut = "Hello"
+
+        // When
+        let size = sut.size(withFont: font, compatibleWith: traits)
+
+        // Then
+        XCTAssertGreaterThan(size.width, 0)
+        XCTAssertGreaterThan(size.height, 0)
+        XCTAssertEqual(size.width, ceil(size.width * scale) / scale)
+        XCTAssertEqual(size.height, ceil(size.height * scale) / scale)
+    }
+
+    func test_sizeWithTypography_deliversRoundedValues() throws {
+        // Given
+        let scale = CGFloat(Int.random(in: 1...3))
+        let traits = UITraitCollection(displayScale: scale)
+        let typography = try XCTUnwrap(getTypographies().randomElement())
+        let sut = "Hello"
+
+        // When
+        let size = sut.size(withTypography: typography, compatibleWith: traits)
+
+        // Then
+        XCTAssertGreaterThan(size.width, 0)
+        XCTAssertGreaterThan(size.height, 0)
+        XCTAssertEqual(size.width, ceil(size.width * scale) / scale)
+        XCTAssertEqual(size.height, ceil(size.height * scale) / scale)
+    }
+
+    func test_sizeWithTypography_deliversLineHeight() {
         // Given
         let typography = Typography(
             fontFamily: Typography.systemFamily,
             fontWeight: .bold,
             fontSize: 24,
             lineHeight: 32,
-            textStyle: .callout
+            textStyle: .title1
         )
         let sut = "testString"
+
         // When
-        let size = sut.size(withTypography: typography, compatibleWith: nil)
+        let size = sut.size(withTypography: typography, compatibleWith: .default)
+
         // Then
         XCTAssertGreaterThan(size.height, 0)
         XCTAssertEqual(size.height, typography.lineHeight)
     }
 
-    func testRelativeWidth() {
+    func test_sizeWithTypography_deliversScaledSize() throws {
+        // Given
+        let typography = try XCTUnwrap(getTypographies().randomElement())
+        let sut = "testString"
+        let traits = UITraitCollection(preferredContentSizeCategory: .accessibilityMedium)
+
+        // When
+        let size = sut.size(withTypography: typography, compatibleWith: traits)
+
+        // Then
+        XCTAssertGreaterThan(size.height, typography.lineHeight)
+    }
+
+    func test_longerStrings_deliverGreaterWidths() {
         // Given
         let typography = Typography(
             fontFamily: Typography.systemFamily,
@@ -37,9 +87,11 @@ final class StringTextSizeTests: XCTestCase {
         )
         let sut1 = "testString1"
         let sut2 = "testString"
+
         // When
-        let sutSize1 = sut1.size(withTypography: typography, compatibleWith: UITraitCollection.default)
-        let sutSize2 = sut2.size(withTypography: typography, compatibleWith: nil)
+        let sutSize1 = sut1.size(withTypography: typography, compatibleWith: .default)
+        let sutSize2 = sut2.size(withTypography: typography, compatibleWith: .default)
+
         // Then
         XCTAssertGreaterThan(sutSize1.height, 0)
         XCTAssertGreaterThan(sutSize2.height, 0)
@@ -47,7 +99,7 @@ final class StringTextSizeTests: XCTestCase {
         XCTAssertEqual(sutSize1.height, sutSize2.height)
     }
 
-    func testWidthIsZero() {
+    func test_emptyString_deliversZeroWidth() {
         // Given
         let typography = Typography(
             fontFamily: Typography.systemFamily,
@@ -57,10 +109,23 @@ final class StringTextSizeTests: XCTestCase {
             textStyle: .caption1
         )
         let sut = ""
+
         // When
         let sutSize = sut.size(withTypography: typography, compatibleWith: nil)
+
         // Then
         XCTAssertGreaterThan(sutSize.height, 0)
         XCTAssertEqual(sutSize.width, 0)
+    }
+}
+
+extension StringTextSizeTests {
+    func getTypographies() -> [Typography] {
+        var typographies: [Typography] = [.systemButton, .systemLabel]
+#if !os(tvOS)
+        typographies.append(.system)
+        typographies.append(.smallSystem)
+#endif
+        return typographies
     }
 }

--- a/Tests/YMatterTypeTests/Extensions/Foundation/String+textSizeTests.swift
+++ b/Tests/YMatterTypeTests/Extensions/Foundation/String+textSizeTests.swift
@@ -1,0 +1,66 @@
+//
+//  String+textSizeTests.swift
+//  YMatterTypeTests
+//
+//  Created by Sahil Saini on 27/03/23.
+//
+
+import XCTest
+@testable import YMatterType
+
+final class StringTextSizeTests: XCTestCase {
+    func testHeightNotZero() {
+        // Given
+        let typography = Typography(
+            fontFamily: Typography.systemFamily,
+            fontWeight: .bold,
+            fontSize: 24,
+            lineHeight: 32,
+            textStyle: .largeTitle
+        )
+        let sut = "testString"
+        // When
+        let size = sut.size(withTypography: typography, compatibleWith: nil)
+        // Then
+        XCTAssertGreaterThan(size.height, 0)
+        XCTAssertEqual(size.height, typography.lineHeight)
+    }
+
+    func testRelativeWidth() {
+        // Given
+        let typography = Typography(
+            fontFamily: Typography.systemFamily,
+            fontWeight: .bold,
+            fontSize: 24,
+            lineHeight: 32,
+            textStyle: .largeTitle
+        )
+        let sut1 = "testString1"
+        let sut2 = "testString"
+        // When
+        let sutSize1 = sut1.size(withTypography: typography, compatibleWith: nil)
+        let sutSize2 = sut2.size(withTypography: typography, compatibleWith: nil)
+        // Then
+        XCTAssertGreaterThan(sutSize1.height, 0)
+        XCTAssertGreaterThan(sutSize2.height, 0)
+        XCTAssertGreaterThan(sutSize1.width, sutSize2.width)
+        XCTAssertEqual(sutSize1.height, sutSize2.height)
+    }
+
+    func testWidthIsZero() {
+        // Given
+        let typography = Typography(
+            fontFamily: Typography.systemFamily,
+            fontWeight: .bold,
+            fontSize: 24,
+            lineHeight: 32,
+            textStyle: .largeTitle
+        )
+        let sut = ""
+        // When
+        let sutSize = sut.size(withTypography: typography, compatibleWith: nil)
+        // Then
+        XCTAssertGreaterThan(sutSize.height, 0)
+        XCTAssertEqual(sutSize.width, 0)
+    }
+}


### PR DESCRIPTION
## Introduction ##

Add method to get text size with given typography. 
## Purpose ##

A new method is added to provide user the access of size of the text.
Fix https://github.com/yml-org/YMatterType/issues/65
## Scope ##

A public method that gives user size of the text.
## 📈 Coverage ##

##### Code #####

~99% code coverage.
<img width="997" alt="Code coverage" src="https://user-images.githubusercontent.com/111066844/228139286-0b447280-d691-4139-b999-7b6392a58b62.png">

##### Documentation #####

100% documentation of public APIs.
<img width="565" alt="Jazzy report 5 42 45 PM" src="https://user-images.githubusercontent.com/111066844/228139397-17637590-eb14-438e-a01e-8453a9241ec3.png">
