### PR TITLE
[Issue 76] Add maximumScaleFactor to Typography

### DIFF
--- a/Sources/YMatterType/Typography/Typography+Font.swift
+++ b/Sources/YMatterType/Typography/Typography+Font.swift
@@ -27,7 +27,7 @@ extension Typography {
         if !isFixed {
             let metrics = UIFontMetrics(forTextStyle: textStyle)
 
-            if let maximumPointSize = maximumPointSize {
+            if let maximumPointSize = getMaximumPointSize(maximumPointSize) {
                 font = metrics.scaledFont(
                     for: font,
                     maximumPointSize: maximumPointSize,
@@ -131,6 +131,32 @@ extension Typography {
         }
 
         return generateLayout(maximumPointSize: maximumPointSize, compatibleWith: traitCollection)
+    }
+
+    /// Maximum point size (if any).
+    ///
+    /// Calculated from `maximumScaleFactor` (if any) multiplied by `fontSize` or else `nil`
+    public var maximumPointSize: CGFloat? {
+        guard let maximumScaleFactor = maximumScaleFactor else {
+            return nil
+        }
+
+        return maximumScaleFactor * fontSize
+    }
+
+    /// Returns the minimum of the point size (if any) or `maximumPointSize` (if any).
+    /// - Parameter pointSize: optional point size to evaluate
+    /// - Returns: the minimum of point size or maximumPointSize
+    internal func getMaximumPointSize(_ pointSize: CGFloat?) -> CGFloat? {
+        guard let maximumPointSize = maximumPointSize else {
+            return pointSize
+        }
+
+        guard let pointSize = pointSize else {
+            return maximumPointSize
+        }
+
+        return min(pointSize, maximumPointSize)
     }
 }
 

--- a/Sources/YMatterType/Typography/Typography+Mutators.swift
+++ b/Sources/YMatterType/Typography/Typography+Mutators.swift
@@ -27,6 +27,7 @@ public extension Typography {
             textCase: textCase,
             textDecoration: textDecoration,
             textStyle: textStyle,
+            maximumScaleFactor: maximumScaleFactor,
             isFixed: isFixed
         )
     }
@@ -58,6 +59,7 @@ public extension Typography {
             textCase: textCase,
             textDecoration: textDecoration,
             textStyle: textStyle,
+            maximumScaleFactor: maximumScaleFactor,
             isFixed: isFixed
         )
     }
@@ -79,6 +81,7 @@ public extension Typography {
             textCase: textCase,
             textDecoration: textDecoration,
             textStyle: textStyle,
+            maximumScaleFactor: maximumScaleFactor,
             isFixed: isFixed
         )
     }
@@ -100,6 +103,7 @@ public extension Typography {
             textCase: textCase,
             textDecoration: textDecoration,
             textStyle: textStyle,
+            maximumScaleFactor: maximumScaleFactor,
             isFixed: isFixed
         )
     }
@@ -119,6 +123,7 @@ public extension Typography {
             textCase: textCase,
             textDecoration: textDecoration,
             textStyle: textStyle,
+            maximumScaleFactor: maximumScaleFactor,
             isFixed: true
         )
     }
@@ -140,6 +145,7 @@ public extension Typography {
             textCase: textCase,
             textDecoration: textDecoration,
             textStyle: textStyle,
+            maximumScaleFactor: maximumScaleFactor,
             isFixed: isFixed
         )
     }
@@ -161,6 +167,7 @@ public extension Typography {
             textCase: value,
             textDecoration: textDecoration,
             textStyle: textStyle,
+            maximumScaleFactor: maximumScaleFactor,
             isFixed: isFixed
         )
     }
@@ -182,6 +189,29 @@ public extension Typography {
             textCase: textCase,
             textDecoration: value,
             textStyle: textStyle,
+            maximumScaleFactor: maximumScaleFactor,
+            isFixed: isFixed
+        )
+    }
+
+    /// Returns a copy of the Typography but with the new `maximumScaleFactor` applied.
+    /// - Parameter value: the maximum scale factor to apply
+    /// - Returns: an updated copy of the Typography
+    func maximumScaleFactor(_ value: CGFloat?) -> Typography {
+        if maximumScaleFactor == value { return self }
+
+        return Typography(
+            fontFamily: fontFamily,
+            fontWeight: fontWeight,
+            fontSize: fontSize,
+            lineHeight: lineHeight,
+            letterSpacing: letterSpacing,
+            paragraphIndent: paragraphIndent,
+            paragraphSpacing: paragraphSpacing,
+            textCase: textCase,
+            textDecoration: textDecoration,
+            textStyle: textStyle,
+            maximumScaleFactor: value,
             isFixed: isFixed
         )
     }

--- a/Sources/YMatterType/Typography/Typography.swift
+++ b/Sources/YMatterType/Typography/Typography.swift
@@ -31,6 +31,11 @@ public struct Typography {
     /// The text style (e.g. Body or Title) that this font most closely represents.
     /// Used for Dynamic Type scaling of the font
     public let textStyle: UIFont.TextStyle
+    /// Maximum scale factor to apply for this typography. `nil` means no limit.
+    ///
+    /// Will not be considered if `isFixed == true`.
+    /// Do not set to `1.0`, but set `isFixed = true` to disable Dynamic Type scaling.
+    public let maximumScaleFactor: CGFloat?
     /// Whether this font is fixed in size or should be scaled through Dynamic Type
     public let isFixed: Bool
 
@@ -54,6 +59,7 @@ public struct Typography {
     ///   - textCase: text case to apply (defaults to `.none`)
     ///   - textDecoration: text decoration to apply (defaults to `.none`)
     ///   - textStyle: text style to use for scaling (defaults to `.body`)
+    ///   - maximumScaleFactor: maximum scale factor to apply (defaults to `nil`)
     ///   - isFixed: `true` if this font should never scale, `false` if it should scale (defaults to `.false`)
     public init(
         fontFamily: FontFamily,
@@ -66,6 +72,7 @@ public struct Typography {
         textCase: TextCase = .none,
         textDecoration: TextDecoration = .none,
         textStyle: UIFont.TextStyle = .body,
+        maximumScaleFactor: CGFloat? = nil,
         isFixed: Bool = false
     ) {
         self.fontFamily = fontFamily
@@ -78,6 +85,7 @@ public struct Typography {
         self.textCase = textCase
         self.textDecoration = textDecoration
         self.textStyle = textStyle
+        self.maximumScaleFactor = maximumScaleFactor
         self.isFixed = isFixed
     }
 
@@ -94,6 +102,7 @@ public struct Typography {
     ///   - textCase: text case to apply (defaults to `.none`)
     ///   - textDecoration: text decoration to apply (defaults to `.none`)
     ///   - textStyle: text style to use for scaling (defaults to `.body`)
+    ///   - maximumScaleFactor: maximum scale factor to apply (defaults to `nil`)
     ///   - isFixed: `true` if this font should never scale, `false` if it should scale (defaults to `.false`)
     public init(
         familyName: String,
@@ -107,6 +116,7 @@ public struct Typography {
         textCase: TextCase = .none,
         textDecoration: TextDecoration = .none,
         textStyle: UIFont.TextStyle = .body,
+        maximumScaleFactor: CGFloat? = nil,
         isFixed: Bool = false
     ) {
         self.init(
@@ -120,6 +130,7 @@ public struct Typography {
             textCase: textCase,
             textDecoration: textDecoration,
             textStyle: textStyle,
+            maximumScaleFactor: maximumScaleFactor,
             isFixed: isFixed
         )
     }

--- a/Tests/YMatterTypeTests/Typography/TypogaphyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/TypogaphyTests.swift
@@ -50,6 +50,7 @@ final class TypogaphyTests: XCTestCase {
         // Confirm default init parameter values
         XCTAssertEqual(typography.letterSpacing, 0)
         XCTAssertEqual(typography.textStyle, UIFont.TextStyle.body)
+        XCTAssertNil(typography.maximumScaleFactor)
         XCTAssertFalse(typography.isFixed)
     }
 }

--- a/Tests/YMatterTypeTests/Typography/Typography+MutatorsTests.swift
+++ b/Tests/YMatterTypeTests/Typography/Typography+MutatorsTests.swift
@@ -101,6 +101,15 @@ final class TypographyMutatorsTests: XCTestCase {
         }
     }
 
+    func testMaximumScaleFactor() {
+        let factors: [CGFloat?] = [nil, 1.5, 2.0, 2.5]
+        types.forEach {
+            for factor in factors {
+                _test(original: $0, modified: $0.maximumScaleFactor(factor), maximumScaleFactor: factor)
+            }
+        }
+    }
+
     private func _test(
         original: Typography,
         modified: Typography,
@@ -111,7 +120,8 @@ final class TypographyMutatorsTests: XCTestCase {
         isFixed: Bool? = nil,
         letterSpacing: CGFloat? = nil,
         textCase: Typography.TextCase? = nil,
-        textDecoration: Typography.TextDecoration? = nil
+        textDecoration: Typography.TextDecoration? = nil,
+        maximumScaleFactor: CGFloat? = nil
     ) {
         let familyName = familyName ?? original.fontFamily.familyName
         let weight = weight ?? original.fontWeight
@@ -121,6 +131,7 @@ final class TypographyMutatorsTests: XCTestCase {
         let kerning = letterSpacing ?? original.letterSpacing
         let textCase = textCase ?? original.textCase
         let textDecoration = textDecoration ?? original.textDecoration
+        let maximumScaleFactor = maximumScaleFactor ?? original.maximumScaleFactor
 
         // familyName, fontWeight, fontSize, lineHeight, isFixed,
         // letterSpacing, textCase, and textDecoration should be as expected
@@ -132,6 +143,7 @@ final class TypographyMutatorsTests: XCTestCase {
         XCTAssertEqual(modified.letterSpacing, kerning)
         XCTAssertEqual(modified.textCase, textCase)
         XCTAssertEqual(modified.textDecoration, textDecoration)
+        XCTAssertEqual(modified.maximumScaleFactor, maximumScaleFactor)
 
         // the other variables should be the same
         XCTAssertEqual(modified.textStyle, original.textStyle)


### PR DESCRIPTION
## Introduction ##

We support setting a maximum scale factor on individual UI elements (buttons, labels, text fields, etc.) but not at the Typography label. If there is an app-wide requirement for a given maximum scale factor (e.g. `2.5`) then it would be onerous to apply because every single label, button, etc would need to set that maximum scale factor. It might be nice to be able to set this at the Typography level and then it would apply to every UI element that makes use of that Typography.

## Purpose ##

Fix #76 Add `maximumScaleFactor` property to `Typography`

## Scope ##

* Add property to `Typography`
* Add new mutator to `Typography`
* Adjust behavior of `Typography.generateLayout`
* Add unit tests

## Discussion ##

I decided that the maximum scale factor should be the minimum of the limit set by the individual UI element (if any) and the Typography (if any). e.g. if label.maximumScaleFactor = 3 and typography.maximumScaleFactor = 2, then 2 will be used.

## Out of Scope ##

I decided not to alter the value of `isFixed` when adjusting `maximumScaleFactor` because that would just complicate the behavior of what is otherwise a pretty simple struct.

## 📈 Coverage ##

##### Code #####

99.2%
<img width="640" alt="image" src="https://user-images.githubusercontent.com/1037520/228431414-b7dab8ac-7277-4278-aad7-b415c34b03d0.png">

##### Documentation #####

100%
<img width="567" alt="image" src="https://user-images.githubusercontent.com/1037520/228431223-15af00ee-e272-449e-b87c-c2c2f499af33.png">
