### PR TITLE
[CM-1428] Fixed swift lint warnings

### DIFF
--- a/Tests/YMatterTypeTests/Elements/TypographyButtonTests.swift
+++ b/Tests/YMatterTypeTests/Elements/TypographyButtonTests.swift
@@ -442,3 +442,5 @@ extension String {
         replacingOccurrences(of: " ", with: "")
     }
 }
+// swiftlint:enable type_body_length
+// swiftlint:enable file_length

--- a/Tests/YMatterTypeTests/Extensions/UIKit/NSParagraphStyle+lineSpacingTests.swift
+++ b/Tests/YMatterTypeTests/Extensions/UIKit/NSParagraphStyle+lineSpacingTests.swift
@@ -132,3 +132,4 @@ private final class NonMutableParagraphStyle: NSParagraphStyle {
         return self
     }
 }
+// swiftlint:enable large_tuple

--- a/Tests/YMatterTypeTests/Extensions/UIKit/UITraitCollection+breakpointTests.swift
+++ b/Tests/YMatterTypeTests/Extensions/UIKit/UITraitCollection+breakpointTests.swift
@@ -91,3 +91,4 @@ private extension UITraitCollectionBreakpointTests {
         ].map({ UITraitCollection(traitsFrom: [startingTraits, $0]) })
     }
 }
+// swiftlint:enable large_tuple

--- a/Tests/YMatterTypeTests/Extensions/UIKit/UITraitCollection+fontAppearanceTests.swift
+++ b/Tests/YMatterTypeTests/Extensions/UIKit/UITraitCollection+fontAppearanceTests.swift
@@ -87,3 +87,4 @@ private extension UITraitCollectionFontAppearanceTests {
         ].map({ UITraitCollection(traitsFrom: [.default, $0]) })
     }
 }
+// swiftlint:enable large_tuple

--- a/Tests/YMatterTypeTests/Typography/FontFamily/FontFamilyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontFamily/FontFamilyTests.swift
@@ -178,3 +178,4 @@ final class WeightlessFontFamily: FontFamily {
 
     func weightName(for weight: Typography.FontWeight) -> String { weightName }
 }
+// swiftlint:enable large_tuple

--- a/Tests/YMatterTypeTests/Typography/FontFamily/SystemFontFamilyTests.swift
+++ b/Tests/YMatterTypeTests/Typography/FontFamily/SystemFontFamilyTests.swift
@@ -130,3 +130,4 @@ private extension SystemFontFamilyTests {
         }
     }
 }
+// swiftlint:enable large_tuple


### PR DESCRIPTION
## Introduction ##

SwiftLint 0.51.0 now requires us to manually re-enable all rules disabled on the file level.
## Purpose ##

Removed SwiftLint warnings
Fix https://github.com/yml-org/YMatterType/issues/83
## Scope ##

Files where any rule of SwiftLint is disabled.
## Out of Scope ##

Any functionality or UI changes.
## 📈 Coverage ##

##### Code #####

No changes.
##### Documentation #####

No changes.